### PR TITLE
Add basic Trip, Hospital and PaymentBill entities

### DIFF
--- a/src/main/java/com/project/Ambulance/model/Hospital.java
+++ b/src/main/java/com/project/Ambulance/model/Hospital.java
@@ -1,4 +1,32 @@
 package com.project.Ambulance.model;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "hospitals")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class Hospital {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int idHospital;
+
+    @Column(columnDefinition = "nvarchar(200) not null")
+    private String nameHospital;
+
+    @Column(columnDefinition = "nvarchar(200)")
+    private String streetAddress;
+
+    @Column(columnDefinition = "nvarchar(100)")
+    private String city;
+
+    @Column(columnDefinition = "nvarchar(100)")
+    private String phone;
+
+    @Column(columnDefinition = "nvarchar(100)")
+    private String email;
 }

--- a/src/main/java/com/project/Ambulance/model/PaymentBill.java
+++ b/src/main/java/com/project/Ambulance/model/PaymentBill.java
@@ -1,4 +1,31 @@
 package com.project.Ambulance.model;
 
+import java.util.Date;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "payment_bills")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
 public class PaymentBill {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int idPaymentBill;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_trip")
+    private Trip trip;
+
+    private double amount;
+
+    private Date paymentDate;
+
+    @Column(columnDefinition = "nvarchar(30)")
+    private String status;
 }

--- a/src/main/java/com/project/Ambulance/model/Trip.java
+++ b/src/main/java/com/project/Ambulance/model/Trip.java
@@ -1,6 +1,7 @@
 package com.project.Ambulance.model;
 
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -8,9 +9,41 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
+@Table(name = "trips")
 @Data
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
 public class Trip {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int idTrip;
+
+    private Date startTime;
+
+    private Date endTime;
+
+    @Column(columnDefinition = "nvarchar(200)")
+    private String originAddress;
+
+    @Column(columnDefinition = "nvarchar(200)")
+    private String destinationAddress;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_vehicle")
+    @JsonIgnore
+    private Vehicle vehicle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "id_driver")
+    @JsonIgnore
+    private User driver;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(name = "trip_medical_staff",
+            joinColumns = @JoinColumn(name = "id_trip"),
+            inverseJoinColumns = @JoinColumn(name = "id_user"))
+    @JsonIgnore
+    private List<User> medicalStaff;
 }


### PR DESCRIPTION
## Summary
- flesh out `Trip` entity with scheduling fields and relations
- add JPA mapped `Hospital` entity
- add JPA mapped `PaymentBill` linked to `Trip`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6854ee8406f48325859a93c5ca0c5d9b