### PR TITLE
Add JpaRepository interfaces for domain entities

### DIFF
--- a/src/main/java/com/project/Ambulance/repository/BrandVehicleRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/BrandVehicleRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.BrandVehicle;
+
+public interface BrandVehicleRepository extends JpaRepository<BrandVehicle, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/DistrictRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/DistrictRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.District;
+
+public interface DistrictRepository extends JpaRepository<District, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/FuelTypeRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/FuelTypeRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.FuelType;
+
+public interface FuelTypeRepository extends JpaRepository<FuelType, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/HospitalRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/HospitalRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Hospital;
+
+public interface HospitalRepository extends JpaRepository<Hospital, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/PaymentBillRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/PaymentBillRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.PaymentBill;
+
+public interface PaymentBillRepository extends JpaRepository<PaymentBill, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/ProvinceRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/ProvinceRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Province;
+
+public interface ProvinceRepository extends JpaRepository<Province, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/RoleRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Role;
+
+public interface RoleRepository extends JpaRepository<Role, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/TripRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/TripRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Trip;
+
+public interface TripRepository extends JpaRepository<Trip, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/UserRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.User;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/VehicleRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/VehicleRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Vehicle;
+
+public interface VehicleRepository extends JpaRepository<Vehicle, Integer> {
+}

--- a/src/main/java/com/project/Ambulance/repository/WardRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/WardRepository.java
@@ -1,0 +1,7 @@
+package com.project.Ambulance.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import com.project.Ambulance.model.Ward;
+
+public interface WardRepository extends JpaRepository<Ward, Integer> {
+}


### PR DESCRIPTION
## Summary
- add `repository` package for Spring Data JPA repositories
- provide `JpaRepository` interfaces for all domain models

## Testing
- `./mvnw -q test` *(fails: could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6854fbd2cc6083258d9370f0c99bd8bb