### PR TITLE
Add service and controller layers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,14 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/project/Ambulance/controller/TripController.java
+++ b/src/main/java/com/project/Ambulance/controller/TripController.java
@@ -1,0 +1,63 @@
+package com.project.Ambulance.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.Ambulance.model.Trip;
+import com.project.Ambulance.service.TripService;
+
+@RestController
+@RequestMapping("/api/trips")
+public class TripController {
+    private final TripService tripService;
+
+    public TripController(TripService tripService) {
+        this.tripService = tripService;
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping
+    public List<Trip> getAll() {
+        return tripService.readAll();
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/{id}")
+    public Optional<Trip> getById(@PathVariable int id) {
+        return tripService.read(id);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public Trip create(@RequestBody Trip trip) {
+        return tripService.create(trip);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public Trip update(@PathVariable int id, @RequestBody Trip trip) {
+        return tripService.update(id, trip);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable int id) {
+        tripService.delete(id);
+    }
+
+    @GetMapping("/assigned")
+    public List<Trip> getAssignedTrips(@RequestParam int userId) {
+        return tripService.getTripsForUser(userId);
+    }
+}

--- a/src/main/java/com/project/Ambulance/controller/VehicleController.java
+++ b/src/main/java/com/project/Ambulance/controller/VehicleController.java
@@ -1,0 +1,55 @@
+package com.project.Ambulance.controller;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.Ambulance.model.Vehicle;
+import com.project.Ambulance.service.VehicleService;
+
+@RestController
+@RequestMapping("/api/vehicles")
+public class VehicleController {
+    private final VehicleService vehicleService;
+
+    public VehicleController(VehicleService vehicleService) {
+        this.vehicleService = vehicleService;
+    }
+
+    @GetMapping
+    public List<Vehicle> getAll() {
+        return vehicleService.readAll();
+    }
+
+    @GetMapping("/{id}")
+    public Optional<Vehicle> getById(@PathVariable int id) {
+        return vehicleService.read(id);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping
+    public Vehicle create(@RequestBody Vehicle vehicle) {
+        return vehicleService.create(vehicle);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @PutMapping("/{id}")
+    public Vehicle update(@PathVariable int id, @RequestBody Vehicle vehicle) {
+        return vehicleService.update(id, vehicle);
+    }
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable int id) {
+        vehicleService.delete(id);
+    }
+}

--- a/src/main/java/com/project/Ambulance/repository/TripRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/TripRepository.java
@@ -1,7 +1,16 @@
 package com.project.Ambulance.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import com.project.Ambulance.model.Trip;
 
 public interface TripRepository extends JpaRepository<Trip, Integer> {
+    List<Trip> findByDriver_IdUser(int driverId);
+
+    @Query("SELECT t FROM Trip t JOIN t.medicalStaff m WHERE m.idUser = :userId")
+    List<Trip> findByMedicalStaffId(@Param("userId") int userId);
 }

--- a/src/main/java/com/project/Ambulance/service/TripService.java
+++ b/src/main/java/com/project/Ambulance/service/TripService.java
@@ -1,0 +1,47 @@
+package com.project.Ambulance.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.project.Ambulance.model.Trip;
+import com.project.Ambulance.repository.TripRepository;
+
+@Service
+public class TripService {
+    private final TripRepository tripRepository;
+
+    public TripService(TripRepository tripRepository) {
+        this.tripRepository = tripRepository;
+    }
+
+    public Trip create(Trip trip) {
+        return tripRepository.save(trip);
+    }
+
+    public List<Trip> readAll() {
+        return tripRepository.findAll();
+    }
+
+    public Optional<Trip> read(int id) {
+        return tripRepository.findById(id);
+    }
+
+    public Trip update(int id, Trip trip) {
+        trip.setIdTrip(id);
+        return tripRepository.save(trip);
+    }
+
+    public void delete(int id) {
+        tripRepository.deleteById(id);
+    }
+
+    public List<Trip> getTripsForUser(int userId) {
+        List<Trip> result = new ArrayList<>();
+        result.addAll(tripRepository.findByDriver_IdUser(userId));
+        result.addAll(tripRepository.findByMedicalStaffId(userId));
+        return result;
+    }
+}

--- a/src/main/java/com/project/Ambulance/service/VehicleService.java
+++ b/src/main/java/com/project/Ambulance/service/VehicleService.java
@@ -1,0 +1,39 @@
+package com.project.Ambulance.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.project.Ambulance.model.Vehicle;
+import com.project.Ambulance.repository.VehicleRepository;
+
+@Service
+public class VehicleService {
+    private final VehicleRepository vehicleRepository;
+
+    public VehicleService(VehicleRepository vehicleRepository) {
+        this.vehicleRepository = vehicleRepository;
+    }
+
+    public Vehicle create(Vehicle vehicle) {
+        return vehicleRepository.save(vehicle);
+    }
+
+    public List<Vehicle> readAll() {
+        return vehicleRepository.findAll();
+    }
+
+    public Optional<Vehicle> read(int id) {
+        return vehicleRepository.findById(id);
+    }
+
+    public Vehicle update(int id, Vehicle vehicle) {
+        vehicle.setIdVehicle(id);
+        return vehicleRepository.save(vehicle);
+    }
+
+    public void delete(int id) {
+        vehicleRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
## Summary
- add VehicleService and TripService with CRUD operations
- expose VehicleController and TripController REST endpoints
- support trip queries for assigned users
- allow admin-only changes via security annotations
- include spring security starter dependency

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6854ff37cf90832589b791cc0d6d3c79