### PR TITLE
Set Java 21 LTS in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This project is a Spring Boot application for managing ambulance services. It de
 
 ## Building with Maven
 
+This project requires **Java 21** or later to compile and run.
+
 The repository includes the Maven wrapper (`mvnw`). Use it to build the project:
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>24</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Summary
- target Java 21 LTS in `pom.xml`
- mention Java 21 requirement in README

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_685502ec08048325ad2108434bc68076