### PR TITLE
Add layout and placeholder admin templates

### DIFF
--- a/src/main/resources/templates/admin/pages/ambulance/form.html
+++ b/src/main/resources/templates/admin/pages/ambulance/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Ambulance Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ambulance/list.html
+++ b/src/main/resources/templates/admin/pages/ambulance/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Ambulance List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ambulanceBrand/form.html
+++ b/src/main/resources/templates/admin/pages/ambulanceBrand/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>AmbulanceBrand Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ambulanceBrand/list.html
+++ b/src/main/resources/templates/admin/pages/ambulanceBrand/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>AmbulanceBrand List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ambulanceLog/form.html
+++ b/src/main/resources/templates/admin/pages/ambulanceLog/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>AmbulanceLog Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ambulanceLog/list.html
+++ b/src/main/resources/templates/admin/pages/ambulanceLog/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>AmbulanceLog List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/district/form.html
+++ b/src/main/resources/templates/admin/pages/district/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>District Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/district/list.html
+++ b/src/main/resources/templates/admin/pages/district/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>District List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/driver/form.html
+++ b/src/main/resources/templates/admin/pages/driver/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Driver Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/driver/list.html
+++ b/src/main/resources/templates/admin/pages/driver/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Driver List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/hospital/form.html
+++ b/src/main/resources/templates/admin/pages/hospital/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Hospital Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/hospital/list.html
+++ b/src/main/resources/templates/admin/pages/hospital/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Hospital List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/maintenanceHistory/form.html
+++ b/src/main/resources/templates/admin/pages/maintenanceHistory/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>MaintenanceHistory Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/maintenanceHistory/list.html
+++ b/src/main/resources/templates/admin/pages/maintenanceHistory/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>MaintenanceHistory List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/medicalStaff/form.html
+++ b/src/main/resources/templates/admin/pages/medicalStaff/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>MedicalStaff Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/medicalStaff/list.html
+++ b/src/main/resources/templates/admin/pages/medicalStaff/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>MedicalStaff List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/province/form.html
+++ b/src/main/resources/templates/admin/pages/province/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Province Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/province/list.html
+++ b/src/main/resources/templates/admin/pages/province/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Province List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/role/form.html
+++ b/src/main/resources/templates/admin/pages/role/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Role Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/role/list.html
+++ b/src/main/resources/templates/admin/pages/role/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Role List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/schedule/form.html
+++ b/src/main/resources/templates/admin/pages/schedule/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Schedule Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/schedule/list.html
+++ b/src/main/resources/templates/admin/pages/schedule/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Schedule List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/transportRequest/form.html
+++ b/src/main/resources/templates/admin/pages/transportRequest/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>TransportRequest Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/transportRequest/list.html
+++ b/src/main/resources/templates/admin/pages/transportRequest/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>TransportRequest List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/user/form.html
+++ b/src/main/resources/templates/admin/pages/user/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>User Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/user/list.html
+++ b/src/main/resources/templates/admin/pages/user/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>User List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ward/form.html
+++ b/src/main/resources/templates/admin/pages/ward/form.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Ward Form</h2>
+</div>
+</html>

--- a/src/main/resources/templates/admin/pages/ward/list.html
+++ b/src/main/resources/templates/admin/pages/ward/list.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="fragments/layout :: layout(~{::content})">
+<div th:fragment="content">
+    <h2>Ward List</h2>
+</div>
+</html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Layout</title>
+</head>
+<body>
+<div th:fragment="layout(content)">
+    <div th:insert="~{fragments/layout :: header}"></div>
+    <div class="container">
+        <div th:insert="~{fragments/layout :: sidebar}"></div>
+        <main>
+            <div th:replace="${content}"></div>
+        </main>
+    </div>
+    <div th:insert="~{fragments/layout :: footer}"></div>
+</div>
+
+<header th:fragment="header">
+    <h1>Ambulance Admin</h1>
+</header>
+
+<aside th:fragment="sidebar">
+    <p>Sidebar</p>
+</aside>
+
+<footer th:fragment="footer">
+    <p>&copy; 2024 Ambulance</p>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add reusable layout template with header, sidebar and footer fragments
- scaffold list and form pages for all admin modules

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685c3c0ca0508325a42357d0d60f12d9