### PR TITLE
Enable auditing on entity timestamps

### DIFF
--- a/src/main/java/com/project/Ambulance/AmbulanceApplication.java
+++ b/src/main/java/com/project/Ambulance/AmbulanceApplication.java
@@ -2,8 +2,10 @@ package com.project.Ambulance;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class AmbulanceApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/project/Ambulance/controller/AmbulanceBrandController.java
+++ b/src/main/java/com/project/Ambulance/controller/AmbulanceBrandController.java
@@ -12,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -93,10 +92,7 @@ public class AmbulanceBrandController {
             AmbulanceBrand oldBrand = ambulanceBrandService.getAmbulanceBrandById(ambulanceBrand.getId());
             if (oldBrand != null) {
                 ambulanceBrand.setCreateDate(oldBrand.getCreateDate());
-            } else {
-                ambulanceBrand.setCreateDate(LocalDate.now());
             }
-            ambulanceBrand.setUpdateDate(LocalDate.now());
 
             // Kiểm tra tên thương hiệu đã tồn tại
             boolean exists = ambulanceBrandService.existsByBrandName(ambulanceBrand.getBrandName());

--- a/src/main/java/com/project/Ambulance/controller/AmbulanceController.java
+++ b/src/main/java/com/project/Ambulance/controller/AmbulanceController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -82,7 +81,6 @@ public class AmbulanceController {
         }
 
         ambulance.setAmbulanceBrand(ambulanceBrandService.getAmbulanceBrandById(brandId));
-        ambulance.setCreateDate(LocalDate.now());
         ambulance.setStatus(Status.AVAILABLE); // Mặc định trạng thái ban đầu
 
         // Upload avatar (ảnh chính)

--- a/src/main/java/com/project/Ambulance/controller/DistrictController.java
+++ b/src/main/java/com/project/Ambulance/controller/DistrictController.java
@@ -14,7 +14,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 
 @Controller
 @RequestMapping("/admin/district")
@@ -97,10 +96,7 @@ public class DistrictController {
             District oldDistrict = districtService.getDistrictById(district.getId());
             if (oldDistrict != null) {
                 district.setCreateDate(oldDistrict.getCreateDate());
-            } else {
-                district.setCreateDate(LocalDate.now());
             }
-            district.setUpdateDate(LocalDate.now());
 
             district.setProvince(provinceService.getProvinceById(provinceId));
 

--- a/src/main/java/com/project/Ambulance/controller/DriverController.java
+++ b/src/main/java/com/project/Ambulance/controller/DriverController.java
@@ -12,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -94,10 +93,7 @@ public class DriverController {
             Driver oldDriver = driverService.getDriverById(driver.getId());
             if (oldDriver != null) {
                 driver.setCreateDate(oldDriver.getCreateDate());
-            } else {
-                driver.setCreateDate(LocalDate.now());
             }
-            driver.setUpdateDate(LocalDate.now());
 
             boolean exists = driverService.existsByUsername(driver.getUsername());
             if (exists && (oldDriver == null || !oldDriver.getUsername().equals(driver.getUsername()))) {

--- a/src/main/java/com/project/Ambulance/controller/HospitalController.java
+++ b/src/main/java/com/project/Ambulance/controller/HospitalController.java
@@ -10,7 +10,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -108,10 +107,7 @@ public class HospitalController {
             Hospital oldHospital = hospitalService.getHospitalById(hospital.getId());
             if (oldHospital != null) {
                 hospital.setCreateDate(oldHospital.getCreateDate());
-            } else {
-                hospital.setCreateDate(LocalDate.now());
             }
-            hospital.setUpdateDate(LocalDate.now());
 
             hospital.setProvince(provinceService.getProvinceById(provinceId));
             hospital.setDistrict(districtService.getDistrictById(districtId));

--- a/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
+++ b/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
@@ -12,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -94,10 +93,7 @@ public class MedicalStaffController {
             MedicalStaff oldStaff = medicalStaffService.getMedicalStaffById(medicalStaff.getId());
             if (oldStaff != null) {
                 medicalStaff.setCreateDate(oldStaff.getCreateDate());
-            } else {
-                medicalStaff.setCreateDate(LocalDate.now());
             }
-            medicalStaff.setUpdateDate(LocalDate.now());
 
             boolean exists = medicalStaffService.existsByUsername(medicalStaff.getUsername());
             if (exists && (oldStaff == null || !oldStaff.getUsername().equals(medicalStaff.getUsername()))) {

--- a/src/main/java/com/project/Ambulance/controller/ProvinceController.java
+++ b/src/main/java/com/project/Ambulance/controller/ProvinceController.java
@@ -12,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 
 @Controller
 @RequestMapping("/admin/province")
@@ -85,10 +84,7 @@ public class ProvinceController {
             Province oldProvince = provinceService.getProvinceById(province.getId());
             if (oldProvince != null) {
                 province.setCreateDate(oldProvince.getCreateDate());
-            } else {
-                province.setCreateDate(LocalDate.now());
             }
-            province.setUpdateDate(LocalDate.now());
 
             boolean exists = provinceService.existsByName(province.getName());
             if (exists && (oldProvince == null || !oldProvince.getName().equals(province.getName()))) {

--- a/src/main/java/com/project/Ambulance/controller/RoleController.java
+++ b/src/main/java/com/project/Ambulance/controller/RoleController.java
@@ -12,7 +12,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 import java.util.List;
 
 @Controller
@@ -86,10 +85,7 @@ public class RoleController {
             Role oldRole = roleService.getRoleById(role.getId());
             if (oldRole != null) {
                 role.setCreateDate(oldRole.getCreateDate());
-            } else {
-                role.setCreateDate(LocalDate.now());
             }
-            role.setUpdateDate(LocalDate.now());
 
             boolean exists = roleService.existsByRoleName(role.getRoleName());
             if (exists && (oldRole == null || !oldRole.getRoleName().equals(role.getRoleName()))) {

--- a/src/main/java/com/project/Ambulance/controller/WardController.java
+++ b/src/main/java/com/project/Ambulance/controller/WardController.java
@@ -16,7 +16,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
-import java.time.LocalDate;
 
 @Controller
 @RequestMapping("/admin/ward")
@@ -105,10 +104,7 @@ public class WardController {
             Ward oldWard = wardService.getWardById(ward.getId());
             if (oldWard != null) {
                 ward.setCreateDate(oldWard.getCreateDate());
-            } else {
-                ward.setCreateDate(LocalDate.now());
             }
-            ward.setUpdateDate(LocalDate.now());
 
             ward.setDistrict(districtService.getDistrictById(districtId));
 

--- a/src/main/java/com/project/Ambulance/model/Ambulance.java
+++ b/src/main/java/com/project/Ambulance/model/Ambulance.java
@@ -3,11 +3,15 @@ package com.project.Ambulance.model;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho xe cứu thương trong hệ thống
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -69,7 +73,9 @@ public class Ambulance {
 
     private LocalDate lastMaintenanceDate; // Ngày bảo trì gần nhất
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/project/Ambulance/model/AmbulanceBrand.java
+++ b/src/main/java/com/project/Ambulance/model/AmbulanceBrand.java
@@ -5,11 +5,15 @@ import lombok.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho thương hiệu xe cứu thương
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,7 +28,9 @@ public class AmbulanceBrand {
     @Column(nullable = false, unique = true, length = 100)
     private String brandName; // Tên thương hiệu (VD: Ford, Toyota, Mercedes...)
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo thương hiệu
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật thương hiệu
 
     /**

--- a/src/main/java/com/project/Ambulance/model/District.java
+++ b/src/main/java/com/project/Ambulance/model/District.java
@@ -5,11 +5,15 @@ import lombok.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Quận / Huyện
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,7 +28,9 @@ public class District {
     @Column(nullable = false, length = 60)
     private String name; // Tên quận/huyện
 
+    @CreatedDate
     private LocalDate createDate;
+    @LastModifiedDate
     private LocalDate updateDate;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/project/Ambulance/model/Driver.java
+++ b/src/main/java/com/project/Ambulance/model/Driver.java
@@ -3,11 +3,15 @@ package com.project.Ambulance.model;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho tài xế xe cứu thương
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -51,6 +55,8 @@ public class Driver {
     @Column(length = 100)
     private String drivingLicenseImage; // Ảnh chụp bằng lái xe
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo tài khoản
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật tài khoản
 }

--- a/src/main/java/com/project/Ambulance/model/Hospital.java
+++ b/src/main/java/com/project/Ambulance/model/Hospital.java
@@ -4,11 +4,15 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho bệnh viện trong hệ thống
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -33,9 +37,11 @@ public class Hospital {
     private String email; // Email bệnh viện
 
     @Column
+    @CreatedDate
     private LocalDate createDate;
 
     @Column
+    @LastModifiedDate
     private LocalDate updateDate;
 
 

--- a/src/main/java/com/project/Ambulance/model/MedicalStaff.java
+++ b/src/main/java/com/project/Ambulance/model/MedicalStaff.java
@@ -3,11 +3,15 @@ package com.project.Ambulance.model;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho nhân viên y tế trong hệ thống
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -48,6 +52,8 @@ public class MedicalStaff {
     @Column(length = 100)
     private String department; // Phòng ban / Khoa công tác
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật
 }

--- a/src/main/java/com/project/Ambulance/model/Province.java
+++ b/src/main/java/com/project/Ambulance/model/Province.java
@@ -5,11 +5,15 @@ import lombok.*;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Tỉnh / Thành phố
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -28,7 +32,9 @@ public class Province {
 
     private String image; // Hình ảnh đại diện (nếu có)
 
+    @CreatedDate
     private LocalDate createDate;
+    @LastModifiedDate
     private LocalDate updateDate;
 
     @OneToMany(mappedBy = "province", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/project/Ambulance/model/Role.java
+++ b/src/main/java/com/project/Ambulance/model/Role.java
@@ -5,11 +5,15 @@ import lombok.*;
 import java.time.LocalDate;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho các quyền hạn trong hệ thống
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,7 +28,9 @@ public class Role {
     @Column(nullable = false, unique = true, length = 50)
     private String roleName; // Tên quyền (ví dụ: ADMIN, DRIVER, MEDICAL_STAFF)
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo quyền
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật quyền
 
     /**

--- a/src/main/java/com/project/Ambulance/model/User.java
+++ b/src/main/java/com/project/Ambulance/model/User.java
@@ -3,11 +3,15 @@ package com.project.Ambulance.model;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Entity đại diện cho người dùng hệ thống (chủ yếu là quản trị viên)
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -53,7 +57,9 @@ public class User {
     private boolean sex;
 
 
+    @CreatedDate
     private LocalDate createDate; // Ngày tạo tài khoản
+    @LastModifiedDate
     private LocalDate updateDate; // Ngày cập nhật tài khoản
 
     /**

--- a/src/main/java/com/project/Ambulance/model/Ward.java
+++ b/src/main/java/com/project/Ambulance/model/Ward.java
@@ -3,11 +3,15 @@ package com.project.Ambulance.model;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDate;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 /**
  * Phường / Xã
  */
 @Entity
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,7 +26,9 @@ public class Ward {
     @Column(nullable = false, length = 150)
     private String name; // Tên phường/xã
 
+    @CreatedDate
     private LocalDate createDate;
+    @LastModifiedDate
     private LocalDate updateDate;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
## Summary
- enable JPA auditing in `AmbulanceApplication`
- annotate entity timestamp fields with `@CreatedDate` and `@LastModifiedDate`
- stop controllers from manually setting creation/update dates

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_685c917a86b88325a0521e01b2bc6167