### PR TITLE
Fix sessionUser typo

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/AmbulanceBrandController.java
+++ b/src/main/java/com/project/Ambulance/controller/AmbulanceBrandController.java
@@ -29,7 +29,7 @@ public class AmbulanceBrandController {
     @GetMapping
     public String listAmbulanceBrand(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("brandList", ambulanceBrandService.getAllAmbulanceBrand());
@@ -42,7 +42,7 @@ public class AmbulanceBrandController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("ambulanceBrand", new AmbulanceBrand());
@@ -56,7 +56,7 @@ public class AmbulanceBrandController {
     @GetMapping("/edit/{id}")
     public String showEditForm(Model model, @PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             AmbulanceBrand ambulanceBrand = ambulanceBrandService.getAmbulanceBrandById(id);
@@ -71,7 +71,7 @@ public class AmbulanceBrandController {
     @GetMapping("/delete/{id}")
     public String deleteAmbulanceBrand(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             ambulanceBrandService.deleteAmbulanceBrand(id);
@@ -87,7 +87,7 @@ public class AmbulanceBrandController {
                                      HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             AmbulanceBrand oldBrand = ambulanceBrandService.getAmbulanceBrandById(ambulanceBrand.getId());

--- a/src/main/java/com/project/Ambulance/controller/AmbulanceLogController.java
+++ b/src/main/java/com/project/Ambulance/controller/AmbulanceLogController.java
@@ -39,7 +39,7 @@ public class AmbulanceLogController {
     @GetMapping
     public String listAmbulanceLogs(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("logs", ambulanceLogService.getAllAmbulanceLog());
@@ -52,7 +52,7 @@ public class AmbulanceLogController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("ambulanceLog", new AmbulanceLog());
@@ -68,7 +68,7 @@ public class AmbulanceLogController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             AmbulanceLog log = ambulanceLogService.getAmbulanceLogById(id);
@@ -85,7 +85,7 @@ public class AmbulanceLogController {
     @GetMapping("/delete/{id}")
     public String deleteAmbulanceLog(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             ambulanceLogService.deleteAmbulanceLog(id);
@@ -103,7 +103,7 @@ public class AmbulanceLogController {
                                    HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/DistrictController.java
+++ b/src/main/java/com/project/Ambulance/controller/DistrictController.java
@@ -33,7 +33,7 @@ public class DistrictController {
     @GetMapping
     public String listDistricts(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("districts", districtService.getAllDistrict());
             model.addAttribute("provinces", provinceService.getAllProvince());
@@ -46,7 +46,7 @@ public class DistrictController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("district", new District());
             model.addAttribute("provinces", provinceService.getAllProvince());
@@ -60,7 +60,7 @@ public class DistrictController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             District district = districtService.getDistrictById(id);
             model.addAttribute("district", district);
@@ -75,7 +75,7 @@ public class DistrictController {
     @GetMapping("/delete/{id}")
     public String deleteDistrict(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             districtService.deleteDistrict(id);
             return "redirect:/admin/district";
@@ -91,7 +91,7 @@ public class DistrictController {
                                HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 
             District oldDistrict = districtService.getDistrictById(district.getId());

--- a/src/main/java/com/project/Ambulance/controller/DriverController.java
+++ b/src/main/java/com/project/Ambulance/controller/DriverController.java
@@ -29,7 +29,7 @@ public class DriverController {
     @GetMapping
     public String listDrivers(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("drivers", driverService.getAllDriver());
@@ -42,7 +42,7 @@ public class DriverController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("driver", new Driver());
@@ -56,7 +56,7 @@ public class DriverController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Driver driver = driverService.getDriverById(id);
@@ -71,7 +71,7 @@ public class DriverController {
     @GetMapping("/delete/{id}")
     public String deleteDriver(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             driverService.deleteDriver(id);
@@ -87,7 +87,7 @@ public class DriverController {
                              HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/HospitalController.java
+++ b/src/main/java/com/project/Ambulance/controller/HospitalController.java
@@ -36,7 +36,7 @@ public class HospitalController {
     @GetMapping
     public String listHospitals(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("hospitals", hospitalService.getAllHospital());
@@ -49,7 +49,7 @@ public class HospitalController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("hospital", new Hospital());
@@ -64,7 +64,7 @@ public class HospitalController {
     @GetMapping("/edit/{id}")
     public String showEditForm(Model model, @PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Hospital hospital = hospitalService.getHospitalById(id);
@@ -82,7 +82,7 @@ public class HospitalController {
     @GetMapping("/delete/{id}")
     public String deleteHospital(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             hospitalService.deleteHospital(id);
@@ -101,7 +101,7 @@ public class HospitalController {
                                HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/MaintenanceHistoryController.java
+++ b/src/main/java/com/project/Ambulance/controller/MaintenanceHistoryController.java
@@ -34,7 +34,7 @@ public class MaintenanceHistoryController {
     @GetMapping
     public String listMaintenanceHistories(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("histories", maintenanceHistoryService.getAllMaintenanceHistory());
@@ -47,7 +47,7 @@ public class MaintenanceHistoryController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("maintenanceHistory", new MaintenanceHistory());
@@ -62,7 +62,7 @@ public class MaintenanceHistoryController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             MaintenanceHistory history = maintenanceHistoryService.getMaintenanceHistoryById(id);
@@ -78,7 +78,7 @@ public class MaintenanceHistoryController {
     @GetMapping("/delete/{id}")
     public String deleteMaintenanceHistory(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             maintenanceHistoryService.deleteMaintenanceHistory(id);
@@ -95,7 +95,7 @@ public class MaintenanceHistoryController {
                                          HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
+++ b/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
@@ -29,7 +29,7 @@ public class MedicalStaffController {
     @GetMapping
     public String listMedicalStaff(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("medicalStaffs", medicalStaffService.getAllMedicalStaff());
@@ -42,7 +42,7 @@ public class MedicalStaffController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("medicalStaff", new MedicalStaff());
@@ -56,7 +56,7 @@ public class MedicalStaffController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             MedicalStaff staff = medicalStaffService.getMedicalStaffById(id);
@@ -71,7 +71,7 @@ public class MedicalStaffController {
     @GetMapping("/delete/{id}")
     public String deleteMedicalStaff(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             medicalStaffService.deleteMedicalStaff(id);
@@ -87,7 +87,7 @@ public class MedicalStaffController {
                                    HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/ProvinceController.java
+++ b/src/main/java/com/project/Ambulance/controller/ProvinceController.java
@@ -28,7 +28,7 @@ public class ProvinceController {
     @GetMapping
     public String listProvinces(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("provinces", provinceService.getAllProvince());
             return "admin/pages/province/list";
@@ -40,7 +40,7 @@ public class ProvinceController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("province", new Province());
             model.addAttribute("action", "Thêm");
@@ -53,7 +53,7 @@ public class ProvinceController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Province province = provinceService.getProvinceById(id);
             model.addAttribute("province", province);
@@ -67,7 +67,7 @@ public class ProvinceController {
     @GetMapping("/delete/{id}")
     public String deleteProvince(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             provinceService.deleteProvince(id);
             return "redirect:/admin/province";
@@ -79,7 +79,7 @@ public class ProvinceController {
     @PostMapping("/save")
     public String saveProvince(@ModelAttribute("province") Province province, RedirectAttributes ra, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 
             Province oldProvince = provinceService.getProvinceById(province.getId());

--- a/src/main/java/com/project/Ambulance/controller/RoleController.java
+++ b/src/main/java/com/project/Ambulance/controller/RoleController.java
@@ -29,7 +29,7 @@ public class RoleController {
     @GetMapping
     public String listRoles(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("roles", roleService.getAllRole());
             return "admin/pages/role/list";
@@ -41,7 +41,7 @@ public class RoleController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("role", new Role());
             model.addAttribute("action", "Thêm");
@@ -54,7 +54,7 @@ public class RoleController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Role role = roleService.getRoleById(id);
             model.addAttribute("role", role);
@@ -68,7 +68,7 @@ public class RoleController {
     @GetMapping("/delete/{id}")
     public String deleteRole(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             roleService.deleteRole(id);
             return "redirect:/admin/role";
@@ -80,7 +80,7 @@ public class RoleController {
     @PostMapping("/save")
     public String saveRole(@ModelAttribute("role") Role role, RedirectAttributes ra, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 
             Role oldRole = roleService.getRoleById(role.getId());

--- a/src/main/java/com/project/Ambulance/controller/ScheduleController.java
+++ b/src/main/java/com/project/Ambulance/controller/ScheduleController.java
@@ -33,7 +33,7 @@ public class ScheduleController {
     @GetMapping
     public String listSchedules(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("schedules", scheduleService.getAllSchedule());
@@ -46,7 +46,7 @@ public class ScheduleController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("schedule", new Schedule());
@@ -63,7 +63,7 @@ public class ScheduleController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Schedule schedule = scheduleService.getScheduleById(id);
@@ -81,7 +81,7 @@ public class ScheduleController {
     @GetMapping("/delete/{id}")
     public String deleteSchedule(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             scheduleService.deleteSchedule(id);
@@ -99,7 +99,7 @@ public class ScheduleController {
                                HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/TransportRequestController.java
+++ b/src/main/java/com/project/Ambulance/controller/TransportRequestController.java
@@ -39,7 +39,7 @@ public class TransportRequestController {
     @GetMapping
     public String listTransportRequests(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("requests", transportRequestService.getAllTransportRequest());
@@ -52,7 +52,7 @@ public class TransportRequestController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("transportRequest", new TransportRequest());
@@ -71,7 +71,7 @@ public class TransportRequestController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             TransportRequest requestEntity = transportRequestService.getTransportRequestById(id);
@@ -91,7 +91,7 @@ public class TransportRequestController {
     @GetMapping("/delete/{id}")
     public String deleteTransportRequest(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             transportRequestService.deleteTransportRequest(id);
@@ -111,7 +111,7 @@ public class TransportRequestController {
                                        HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 

--- a/src/main/java/com/project/Ambulance/controller/UserController.java
+++ b/src/main/java/com/project/Ambulance/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
     @GetMapping
     public String listUsers(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("users", userService.getAllUser());
@@ -48,7 +48,7 @@ public class UserController {
     @GetMapping("/delete/{id}")
     public String deleteUser(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             userService.deleteUser(id);
@@ -61,7 +61,7 @@ public class UserController {
     @GetMapping("/reset-password/{id}")
     public String resetPassword(@PathVariable("id") Long id, RedirectAttributes ra, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             User user = userService.getUserById(id);
@@ -80,7 +80,7 @@ public class UserController {
     public String uploadAvatar(HttpServletRequest request,
                                @RequestParam("avatarImage") MultipartFile image) {
         HttpSession session = request.getSession();
-        User user = (User) session.getAttribute("sesionUser");
+        User user = (User) session.getAttribute("sessionUser");
 
         if (user != null) {
             uploadFileService.removeFile(user.getImage());
@@ -103,7 +103,7 @@ public class UserController {
                                  @RequestParam("addressDetail") String addressDetail) {
 
         HttpSession session = request.getSession();
-        User user = (User) session.getAttribute("sesionUser");
+        User user = (User) session.getAttribute("sessionUser");
 
         if (user != null) {
             user.setNameDisplay(nameDisplay);
@@ -125,7 +125,7 @@ public class UserController {
     @PostMapping("/update-phone")
     public String updatePhone(HttpServletRequest request, @RequestParam("phone") String phone) {
         HttpSession session = request.getSession();
-        User user = (User) session.getAttribute("sesionUser");
+        User user = (User) session.getAttribute("sessionUser");
 
         if (user != null) {
             user.setPhone(phone);
@@ -139,7 +139,7 @@ public class UserController {
     @PostMapping("/update-email")
     public String updateEmail(HttpServletRequest request, @RequestParam("email") String email) {
         HttpSession session = request.getSession();
-        User user = (User) session.getAttribute("sesionUser");
+        User user = (User) session.getAttribute("sessionUser");
 
         if (user != null) {
             user.setEmail(email);
@@ -156,7 +156,7 @@ public class UserController {
                                        @RequestParam(name = "licenseImage", required = false) MultipartFile licenseImage) {
 
         HttpSession session = request.getSession();
-        User user = (User) session.getAttribute("sesionUser");
+        User user = (User) session.getAttribute("sessionUser");
 
         if (user != null) {
             user.setDrivingLicense(drivingLicense);

--- a/src/main/java/com/project/Ambulance/controller/WardController.java
+++ b/src/main/java/com/project/Ambulance/controller/WardController.java
@@ -38,7 +38,7 @@ public class WardController {
     @GetMapping
     public String listWards(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("wards", wardService.getAllWard());
             model.addAttribute("districts", districtService.getAllDistrict());
@@ -52,7 +52,7 @@ public class WardController {
     @GetMapping("/add")
     public String showAddForm(Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             model.addAttribute("ward", new Ward());
             model.addAttribute("provinces", provinceService.getAllProvince());
@@ -67,7 +67,7 @@ public class WardController {
     @GetMapping("/edit/{id}")
     public String showEditForm(@PathVariable("id") Long id, Model model, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             Ward ward = wardService.getWardById(id);
             model.addAttribute("ward", ward);
@@ -83,7 +83,7 @@ public class WardController {
     @GetMapping("/delete/{id}")
     public String deleteWard(@PathVariable("id") Long id, HttpServletRequest request) {
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             wardService.deleteWard(id);
             return "redirect:/admin/ward";
@@ -99,7 +99,7 @@ public class WardController {
                            HttpServletRequest request) {
 
         HttpSession session = request.getSession();
-        User sessionUser = (User) session.getAttribute("sesionUser");
+        User sessionUser = (User) session.getAttribute("sessionUser");
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
 
             Ward oldWard = wardService.getWardById(ward.getId());

--- a/src/main/resources/templates/pages/layout/header.html
+++ b/src/main/resources/templates/pages/layout/header.html
@@ -28,17 +28,17 @@
 					<li class="nav-item"><a class="nav-link" th:href="@{/blog}">Blogs</a></li>
 					<li class="nav-item"><a class="nav-link" th:href="@{/lien-he}">Liên
 							hệ</a></li>
-					<th:block th:unless="${session.sesionUser}">
+					<th:block th:unless="${session.sessionUser}">
 						<li class="nav-item"><a class="nav-link" th:href="@{/login}">Đăng
 								nhập</a></li>
 						<li class="nav-item"><a class="nav-link" th:href="@{/sign-up}">Đăng kí</a>
 					</th:block>
-					<th:block th:if="${session.sesionUser}">
+					<th:block th:if="${session.sessionUser}">
 
 						<li class="nav-item dropdown"><a class="nav-link dropdown-toggle" href="#"
 								id="navbarDarkDropdownMenuLink" role="button" data-bs-toggle="dropdown"
 								aria-expanded="false"> Xin chào, <span
-									th:text="${session.sesionUser.nameDisplay}"></span>
+									th:text="${session.sessionUser.nameDisplay}"></span>
 							</a>
 							<ul class="dropdown-menu dropdown-menu-acc " aria-labelledby="navbarDarkDropdownMenuLink">
 								<li><a class="dropdown-item" th:href="@{/edit-profile}">Tài


### PR DESCRIPTION
## Summary
- fix misspelled `sesionUser` key across controllers and views
- update header view to use `session.sessionUser`

## Testing
- `./mvnw -q test` *(fails: wget Failed to fetch https://repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_685cc7cbe3f8832588be06f16b5cfa91