### PR TITLE
Add password hashing with Spring Security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,11 +67,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jdbc</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-security</artifactId>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/src/main/java/com/project/Ambulance/config/SecurityConfig.java
+++ b/src/main/java/com/project/Ambulance/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.project.Ambulance.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/Ambulance/controller/UserController.java
+++ b/src/main/java/com/project/Ambulance/controller/UserController.java
@@ -3,6 +3,7 @@ package com.project.Ambulance.controller;
 import com.project.Ambulance.model.*;
 import com.project.Ambulance.service.*;
 import com.project.Ambulance.service.UploadFileService;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,9 @@ public class UserController {
 
     @Autowired
     private UploadFileService uploadFileService;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     // Hiển thị danh sách tài khoản người dùng
     @GetMapping
@@ -65,7 +69,7 @@ public class UserController {
 
         if (sessionUser != null && sessionUser.getRole().getRoleName().equals("ADMIN")) {
             User user = userService.getUserById(id);
-            user.setPassword("123"); // Tạm hard-code reset (sau này dùng bcrypt encoder chuẩn)
+            user.setPassword(passwordEncoder.encode("123"));
             userService.saveUser(user);
             ra.addFlashAttribute("messResetPass", "Reset mật khẩu thành công");
             return "redirect:/admin/user";

--- a/src/main/java/com/project/Ambulance/service/UserServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.project.Ambulance.service;
 import com.project.Ambulance.model.User;
 import com.project.Ambulance.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +14,9 @@ public class UserServiceImpl implements UserService {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
 
     @Override
     public List<User> getAllUser() {
@@ -31,6 +35,12 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void saveUser(User user) {
+        if (user.getPassword() != null &&
+                !(user.getPassword().startsWith("$2a$") ||
+                  user.getPassword().startsWith("$2b$") ||
+                  user.getPassword().startsWith("$2y$"))) {
+            user.setPassword(passwordEncoder.encode(user.getPassword()));
+        }
         userRepository.save(user);
     }
 


### PR DESCRIPTION
## Summary
- include spring-security dependency
- provide a `PasswordEncoder` bean using `BCryptPasswordEncoder`
- hash passwords when resetting a user's password
- ensure service encodes raw passwords before persisting

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685cc9a46010832585d5d596df4a158f