### PR TITLE
Introduce configurable upload directory

### DIFF
--- a/src/main/java/com/project/Ambulance/service/UploadFileServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/UploadFileServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.Ambulance.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -16,12 +17,14 @@ import java.util.Random;
 public class UploadFileServiceImpl implements UploadFileService {
 
     private static final int LENGTH_MAX = 7;
-    private static final String UPLOAD_DIR = "uploads/";
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
 
     @Override
     public String uploadSingleFile(MultipartFile file) {
         String fileName = "";
-        Path path = Paths.get(UPLOAD_DIR);
+        Path path = Paths.get(uploadDir);
         try {
             InputStream inputStream = file.getInputStream();
             String timestamp = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date());
@@ -48,7 +51,7 @@ public class UploadFileServiceImpl implements UploadFileService {
 
     @Override
     public void removeFile(String nameFile) {
-        Path path = Paths.get(UPLOAD_DIR);
+        Path path = Paths.get(uploadDir);
         try {
             Files.deleteIfExists(path.resolve(nameFile));
         } catch (Exception e) {
@@ -59,7 +62,7 @@ public class UploadFileServiceImpl implements UploadFileService {
     @Override
     public String uploadFileDocument(MultipartFile file) {
         String fileName = file.getOriginalFilename().trim();
-        Path path = Paths.get(UPLOAD_DIR);
+        Path path = Paths.get(uploadDir);
         try {
             InputStream inputStream = file.getInputStream();
             Files.copy(inputStream, path.resolve(fileName), StandardCopyOption.REPLACE_EXISTING);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
+
+# Directory where uploaded files are stored
+file.upload-dir=uploads/


### PR DESCRIPTION
## Summary
- make file upload directory configurable via application.properties
- inject `file.upload-dir` property into `UploadFileServiceImpl`

## Testing
- `mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685ccab815688325be625478bf83c6b2