### PR TITLE
Add dedicated PasswordEncoder bean

### DIFF
--- a/src/main/java/com/project/Ambulance/config/PasswordConfig.java
+++ b/src/main/java/com/project/Ambulance/config/PasswordConfig.java
@@ -1,0 +1,14 @@
+package com.project.Ambulance.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/Ambulance/config/SecurityConfig.java
+++ b/src/main/java/com/project/Ambulance/config/SecurityConfig.java
@@ -7,8 +7,6 @@ import com.project.Ambulance.service.UserService;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -44,8 +42,4 @@ public class SecurityConfig {
         };
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 }


### PR DESCRIPTION
## Summary
- add `PasswordConfig` to hold the `PasswordEncoder` bean
- remove password encoder bean from `SecurityConfig`
- keep password encoder injection in `UserServiceImpl`

## Testing
- `./mvnw -q test` *(fails: Permission denied or missing Maven)*
- `./mvnw -q -DskipTests spring-boot:run` *(fails: unable to fetch Maven distribution)*

------
https://chatgpt.com/codex/tasks/task_b_685d0abb92008325885c202d080259f1