### PR TITLE
Add HomeController with dashboard logic

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/HomeController.java
+++ b/src/main/java/com/project/Ambulance/controller/HomeController.java
@@ -1,0 +1,26 @@
+package com.project.Ambulance.controller;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String home() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()
+                && !(authentication instanceof AnonymousAuthenticationToken)) {
+            return "redirect:/dashboard";
+        }
+        return "redirect:/login";
+    }
+
+    @GetMapping("/dashboard")
+    public String dashboard() {
+        return "pages/dashboard";
+    }
+}


### PR DESCRIPTION
## Summary
- create `HomeController` with `/` and `/dashboard` endpoints
- redirect authenticated users from root to `/dashboard`
- show dashboard page when `/dashboard` is visited

## Testing
- `./mvnw -q test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685d2e9a01ec8325aac55a581a6ae724