### PR TITLE
Update SecurityConfig to restrict access

### DIFF
--- a/src/main/java/com/project/Ambulance/config/SecurityConfig.java
+++ b/src/main/java/com/project/Ambulance/config/SecurityConfig.java
@@ -22,7 +22,8 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> auth
                     .requestMatchers("/admin/**").hasRole("ADMIN")
-                    .anyRequest().permitAll())
+                    .requestMatchers("/login", "/register", "/css/**", "/lib/**").permitAll()
+                    .anyRequest().authenticated())
             .formLogin(login -> login.loginPage("/login").permitAll())
             .logout(logout -> logout.logoutSuccessUrl("/login?logout").permitAll());
         return http.build();


### PR DESCRIPTION
## Summary
- restrict default access rules to require authentication
- allow public access to login/register resources

## Testing
- `./mvnw -q test` *(fails: unable to download Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_b_685d32fc8b208325b9d6ded361c695f9