### PR TITLE
Fix Thymeleaf layout

### DIFF
--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
+      th:fragment="layout (content)"
       lang="vi">
 <head>
     <meta charset="UTF-8">

--- a/src/main/resources/templates/fragments/script.html
+++ b/src/main/resources/templates/fragments/script.html
@@ -1,0 +1,3 @@
+<div th:fragment="script">
+    <!-- Additional scripts can be added per page -->
+</div>


### PR DESCRIPTION
## Summary
- define missing `layout` fragment
- add placeholder script fragment to prevent 500 errors

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch https://repo.maven.apache.org/...)*
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_b_685d38038c3883258db00ecbb5e7e9a1