### PR TITLE
Fix typos in service method names

### DIFF
--- a/src/main/java/com/project/Ambulance/service/DistrictService.java
+++ b/src/main/java/com/project/Ambulance/service/DistrictService.java
@@ -6,7 +6,7 @@ import com.project.Ambulance.model.District;
 
 
 public interface DistrictService {
-	List<District> getAllDistricWithProvenice();
+       List<District> getAllDistrictWithProvince();
 	void saveDistrict(District d);
 	District getDistrict(int id);
 	void deleteDistrict(int id);

--- a/src/main/java/com/project/Ambulance/service/DistrictServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/DistrictServiceImpl.java
@@ -15,11 +15,11 @@ public class DistrictServiceImpl implements DistrictService {
 	@Autowired
 	private DistrictRepository repo;
 	
-	@Override
-	public List<District> getAllDistricWithProvenice() {
+       @Override
+       public List<District> getAllDistrictWithProvince() {
 		
-		return repo.getAllDistrictWithProvince();
-	}
+               return repo.getAllDistrictWithProvince();
+       }
 
 	@Override
 	public void saveDistrict(District d) {

--- a/src/main/java/com/project/Ambulance/service/ProvinceService.java
+++ b/src/main/java/com/project/Ambulance/service/ProvinceService.java
@@ -6,9 +6,9 @@ import com.project.Ambulance.model.Province;
 
 public interface ProvinceService {
 	
-	List<Province> getAllProvinceOrderByName();
-	void saveProvices(Province p);
-	Province getProvince(int id);
-	void deleteProvince(int id);
+       List<Province> getAllProvinceOrderByName();
+       void saveProvince(Province p);
+       Province getProvince(int id);
+       void deleteProvince(int id);
 
 }

--- a/src/main/java/com/project/Ambulance/service/ProvinceServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/ProvinceServiceImpl.java
@@ -20,11 +20,11 @@ public class ProvinceServiceImpl  implements ProvinceService{
 		return repo.findAllProvinceOrderByName();
 	}
 
-	@Override
-	public void saveProvices(Province p) {
-		repo.save(p);
-		
-	}
+       @Override
+       public void saveProvince(Province p) {
+               repo.save(p);
+
+       }
 
 	@Override
 	public Province getProvince(int id) {

--- a/src/main/java/com/project/Ambulance/service/WardService.java
+++ b/src/main/java/com/project/Ambulance/service/WardService.java
@@ -12,7 +12,7 @@ public interface WardService {
 	Ward getAWard(int id);
 	void saveWard(Ward ward);
 	void deleteWard(int id);
-	List<Ward> getAllWardByIdDistric(int idDistrict);
+       List<Ward> getAllWardByIdDistrict(int idDistrict);
 	
  	
 }

--- a/src/main/java/com/project/Ambulance/service/WardServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/WardServiceImpl.java
@@ -54,11 +54,11 @@ public class WardServiceImpl  implements WardService{
 		return repo.getAllWardWithDistrictAndProvinces();
 	}
 
-	@Override
-	public List<Ward> getAllWardByIdDistric(int idDistrict) {
+       @Override
+       public List<Ward> getAllWardByIdDistrict(int idDistrict) {
 		
-		return repo.findWardByDistrictIdDistrict(idDistrict);
-	}
+               return repo.findWardByDistrictIdDistrict(idDistrict);
+       }
 
 	
 }


### PR DESCRIPTION
## Summary
- rename `saveProvices` → `saveProvince`
- rename `getAllDistricWithProvenice` → `getAllDistrictWithProvince`
- rename `getAllWardByIdDistric` → `getAllWardByIdDistrict`
- update service implementations

## Testing
- `./mvnw -q test` *(fails: wget unable to fetch from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_68618b8bbb48832583994b38a8e867b3