### PR TITLE
Fix interface name typo

### DIFF
--- a/src/main/java/com/project/Ambulance/constants/FieldName.java
+++ b/src/main/java/com/project/Ambulance/constants/FieldName.java
@@ -1,6 +1,6 @@
 package com.project.Ambulance.constants;
 
-public interface FiledName {
+public interface FieldName {
 	// User Roles
 	public static final int ROLE_ADMIN = 1;
 	public static final int ROLE_MEDICAL_STAFF = 2;


### PR DESCRIPTION
## Summary
- rename `FiledName` to `FieldName`
- update the interface declaration accordingly

## Testing
- `bash ./mvnw -q -DskipTests package` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68618cb4d8c88325931b5906e124cabe