### PR TITLE
Add basic authentication controller

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/AuthController.java
+++ b/src/main/java/com/project/Ambulance/controller/AuthController.java
@@ -1,0 +1,97 @@
+package com.project.Ambulance.controller;
+
+import com.project.Ambulance.model.Role;
+import com.project.Ambulance.model.User;
+import com.project.Ambulance.service.RoleService;
+import com.project.Ambulance.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.Date;
+
+@Controller
+public class AuthController {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private RoleService roleService;
+
+    // Show login page
+    @GetMapping({"/", "/login"})
+    public String showLogin(@RequestParam(value = "success", required = false) String success,
+                            Model model) {
+        if (success != null) {
+            model.addAttribute("success", success);
+        }
+        return "login";
+    }
+
+    // Show register page
+    @GetMapping("/register")
+    public String showRegister() {
+        return "register";
+    }
+
+    // Handle login
+    @PostMapping("/login")
+    public String doLogin(@RequestParam String username,
+                          @RequestParam String password,
+                          HttpSession session,
+                          Model model) {
+        User user = userService.getUserByUsername(username);
+        if (user != null && password.equals(user.getPassword())) {
+            session.setAttribute("loggedInUser", user);
+            String roleName = user.getRole().getName();
+            if ("ADMIN".equalsIgnoreCase(roleName)) {
+                return "redirect:/admin/dashboard";
+            } else if ("DRIVER".equalsIgnoreCase(roleName)) {
+                return "redirect:/driver/dashboard";
+            } else if ("MEDICAL".equalsIgnoreCase(roleName)) {
+                return "redirect:/medical/dashboard";
+            }
+            return "redirect:/";
+        }
+        model.addAttribute("error", "Sai tên đăng nhập hoặc mật khẩu");
+        return "login";
+    }
+
+    // Handle register
+    @PostMapping("/register")
+    public String doRegister(@RequestParam String username,
+                             @RequestParam String password,
+                             Model model) {
+        if (userService.getUserByUsername(username) != null) {
+            model.addAttribute("error", "Username đã tồn tại");
+            return "register";
+        }
+        User user = new User();
+        user.setUsername(username);
+        user.setPassword(password);
+        user.setCreateDate(new Date());
+        Role staffRole = roleService.getRoleByName("STAFF");
+        user.setRole(staffRole);
+        userService.saveUser(user);
+        model.addAttribute("success", "Đăng ký thành công");
+        return "login";
+    }
+
+    // Logout
+    @GetMapping("/logout")
+    public String logout(HttpSession session) {
+        session.invalidate();
+        return "redirect:/logout-success";
+    }
+
+    @GetMapping("/logout-success")
+    public String logoutSuccess(Model model) {
+        model.addAttribute("success", "Đăng xuất thành công");
+        return "login";
+    }
+}

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Đăng nhập</title>
+</head>
+<body>
+<h2>Đăng nhập</h2>
+<p th:text="${error}" style="color:red"></p>
+<p th:text="${success}" style="color:green"></p>
+<form th:action="@{/login}" method="post">
+    <label>Username:</label>
+    <input type="text" name="username"/>
+    <br/>
+    <label>Password:</label>
+    <input type="password" name="password"/>
+    <br/>
+    <button type="submit">Login</button>
+</form>
+<p><a th:href="@{/register}">Đăng ký</a></p>
+</body>
+</html>

--- a/src/main/resources/templates/register.html
+++ b/src/main/resources/templates/register.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Đăng ký</title>
+</head>
+<body>
+<h2>Đăng ký</h2>
+<p th:text="${error}" style="color:red"></p>
+<form th:action="@{/register}" method="post">
+    <label>Username:</label>
+    <input type="text" name="username"/>
+    <br/>
+    <label>Password:</label>
+    <input type="password" name="password"/>
+    <br/>
+    <button type="submit">Register</button>
+</form>
+<p><a th:href="@{/login}">Đăng nhập</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement `AuthController` for login, register and logout handling
- add simple `login.html` and `register.html` templates

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686197cda8cc8325ab6d7cbe2f7c6ba4