### PR TITLE
Add admin section templates

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -20,4 +20,24 @@ public class DashboardController {
     public String medicalDashboard() {
         return "medical/dashboard";
     }
+
+    @GetMapping("/admin/ambulances")
+    public String manageAmbulances() {
+        return "admin/ambulances";
+    }
+
+    @GetMapping("/admin/hospitals")
+    public String manageHospitals() {
+        return "admin/hospitals";
+    }
+
+    @GetMapping("/admin/drivers")
+    public String manageDrivers() {
+        return "admin/drivers";
+    }
+
+    @GetMapping("/admin/bookings")
+    public String bookingHistory() {
+        return "admin/booking-history";
+    }
 }

--- a/src/main/resources/templates/admin/ambulances.html
+++ b/src/main/resources/templates/admin/ambulances.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Ambulances</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý xe cứu thương</h2>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/booking-history.html
+++ b/src/main/resources/templates/admin/booking-history.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Booking History</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Lịch sử điều xe</h2>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/drivers.html
+++ b/src/main/resources/templates/admin/drivers.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Drivers</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý tài xế</h2>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/admin/hospitals.html
+++ b/src/main/resources/templates/admin/hospitals.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Hospitals</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý bệnh viện</h2>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -5,10 +5,10 @@
     <ul class="nav nav-pills flex-column mb-auto" th:switch="${session.loggedInUser?.role?.name}">
         <th:block th:case="'ADMIN'">
             <li class="nav-item"><a class="nav-link" th:href="@{/admin/dashboard}">Dashboard</a></li>
-            <li><a class="nav-link" href="#">Quản lý xe</a></li>
-            <li><a class="nav-link" href="#">Quản lý bệnh viện</a></li>
-            <li><a class="nav-link" href="#">Quản lý tài xế</a></li>
-            <li><a class="nav-link" href="#">Lịch sử điều xe</a></li>
+            <li><a class="nav-link" th:href="@{/admin/ambulances}">Quản lý xe</a></li>
+            <li><a class="nav-link" th:href="@{/admin/hospitals}">Quản lý bệnh viện</a></li>
+            <li><a class="nav-link" th:href="@{/admin/drivers}">Quản lý tài xế</a></li>
+            <li><a class="nav-link" th:href="@{/admin/bookings}">Lịch sử điều xe</a></li>
         </th:block>
         <th:block th:case="'DRIVER'">
             <li class="nav-item"><a class="nav-link" th:href="@{/driver/dashboard}">Dashboard</a></li>


### PR DESCRIPTION
## Summary
- create admin templates for ambulance, hospital, driver, and booking history management
- add routes in `DashboardController` for the new views
- link admin pages in sidebar

## Testing
- `./mvnw -q test` *(fails: unable to download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6861b467e1c88325a4309d34429d3688