### PR TITLE
Add profile and schedule pages

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -16,9 +16,29 @@ public class DashboardController {
         return "driver/dashboard";
     }
 
+    @GetMapping("/driver/profile")
+    public String driverProfile() {
+        return "driver/profile";
+    }
+
+    @GetMapping("/driver/schedule")
+    public String driverSchedule() {
+        return "driver/schedule";
+    }
+
     @GetMapping("/medical/dashboard")
     public String medicalDashboard() {
         return "medical/dashboard";
+    }
+
+    @GetMapping("/medical/profile")
+    public String medicalProfile() {
+        return "medical/profile";
+    }
+
+    @GetMapping("/medical/schedule")
+    public String medicalSchedule() {
+        return "medical/schedule";
     }
 
     @GetMapping("/admin/ambulances")

--- a/src/main/resources/templates/driver/profile.html
+++ b/src/main/resources/templates/driver/profile.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Driver Profile</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Thông tin cá nhân</h2>
+        <form>
+            <div class="mb-3">
+                <label class="form-label">Họ tên</label>
+                <input type="text" class="form-control" name="name"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" class="form-control" name="phone"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" class="form-control" name="email"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Ngày sinh</label>
+                <input type="text" class="form-control" name="dateOfBirth"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Số bằng lái</label>
+                <input type="text" class="form-control" name="licenseNumber"/>
+            </div>
+            <button type="submit" class="btn btn-primary">Lưu</button>
+        </form>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/driver/schedule.html
+++ b/src/main/resources/templates/driver/schedule.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Driver Schedule</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Lịch lái xe</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Mã ca</th>
+                    <th>Thời gian</th>
+                    <th>Điểm đón</th>
+                    <th>Bệnh viện</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="b : ${bookings}">
+                    <td th:text="${b.idBooking}"></td>
+                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${b.pickupAddress}"></td>
+                    <td th:text="${b.hospital.name}"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -12,13 +12,13 @@
         </th:block>
         <th:block th:case="'DRIVER'">
             <li class="nav-item"><a class="nav-link" th:href="@{/driver/dashboard}">Dashboard</a></li>
-            <li><a class="nav-link" href="#">Thông tin cá nhân</a></li>
-            <li><a class="nav-link" href="#">Lịch lái xe</a></li>
+            <li><a class="nav-link" th:href="@{/driver/profile}">Thông tin cá nhân</a></li>
+            <li><a class="nav-link" th:href="@{/driver/schedule}">Lịch lái xe</a></li>
         </th:block>
         <th:block th:case="'MEDICAL'">
             <li class="nav-item"><a class="nav-link" th:href="@{/medical/dashboard}">Dashboard</a></li>
-            <li><a class="nav-link" href="#">Thông tin cá nhân</a></li>
-            <li><a class="nav-link" href="#">Lịch đi kèm</a></li>
+            <li><a class="nav-link" th:href="@{/medical/profile}">Thông tin cá nhân</a></li>
+            <li><a class="nav-link" th:href="@{/medical/schedule}">Lịch đi kèm</a></li>
         </th:block>
     </ul>
 </nav>

--- a/src/main/resources/templates/medical/profile.html
+++ b/src/main/resources/templates/medical/profile.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Medical Profile</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Thông tin cá nhân</h2>
+        <form>
+            <div class="mb-3">
+                <label class="form-label">Họ tên</label>
+                <input type="text" class="form-control" name="name"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" class="form-control" name="phone"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" class="form-control" name="email"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Ngày sinh</label>
+                <input type="text" class="form-control" name="dateOfBirth"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Số giấy phép</label>
+                <input type="text" class="form-control" name="licenseNumber"/>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Chuyên môn</label>
+                <input type="text" class="form-control" name="specialization"/>
+            </div>
+            <button type="submit" class="btn btn-primary">Lưu</button>
+        </form>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>

--- a/src/main/resources/templates/medical/schedule.html
+++ b/src/main/resources/templates/medical/schedule.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Medical Schedule</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Lịch đi kèm</h2>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>Mã ca</th>
+                    <th>Thời gian</th>
+                    <th>Điểm đón</th>
+                    <th>Bệnh viện</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr th:each="b : ${bookings}">
+                    <td th:text="${b.idBooking}"></td>
+                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${b.pickupAddress}"></td>
+                    <td th:text="${b.hospital.name}"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add profile & schedule templates for driver and medical staff
- link new pages in sidebar
- map profile and schedule routes in `DashboardController`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6861b563e78c8325b6196965a53fd737