### PR TITLE
Add dashboard assets

### DIFF
--- a/src/main/resources/static/css/dashboard.css
+++ b/src/main/resources/static/css/dashboard.css
@@ -1,0 +1,24 @@
+/* Custom styles for dashboard tables and forms */
+
+/* Table styling */
+table.table {
+    border: 1px solid #dee2e6;
+}
+
+table.table thead {
+    background-color: #f8f9fa;
+}
+
+table.table tbody tr:hover {
+    background-color: #f1f1f1;
+}
+
+/* Form styling */
+form .form-control:focus {
+    box-shadow: 0 0 0 .2rem rgba(13, 110, 253, .25);
+    border-color: #0d6efd;
+}
+
+form.was-validated .form-control:invalid {
+    border-color: #dc3545;
+}

--- a/src/main/resources/static/js/dashboard.js
+++ b/src/main/resources/static/js/dashboard.js
@@ -1,0 +1,15 @@
+// Simple client-side validation for forms with the 'needs-validation' class
+
+window.addEventListener('DOMContentLoaded', function () {
+    const forms = document.querySelectorAll('form.needs-validation');
+    Array.prototype.slice.call(forms)
+        .forEach(function (form) {
+            form.addEventListener('submit', function (event) {
+                if (!form.checkValidity()) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                form.classList.add('was-validated');
+            }, false);
+        });
+});

--- a/src/main/resources/templates/admin/ambulances.html
+++ b/src/main/resources/templates/admin/ambulances.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Manage Ambulances</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -14,5 +15,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/booking-history.html
+++ b/src/main/resources/templates/admin/booking-history.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Booking History</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -14,5 +15,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/drivers.html
+++ b/src/main/resources/templates/admin/drivers.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Manage Drivers</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -14,5 +15,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/admin/hospitals.html
+++ b/src/main/resources/templates/admin/hospitals.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Manage Hospitals</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -14,5 +15,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/driver/dashboard.html
+++ b/src/main/resources/templates/driver/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Driver Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -32,5 +33,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/driver/profile.html
+++ b/src/main/resources/templates/driver/profile.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Driver Profile</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -11,31 +12,32 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Thông tin cá nhân</h2>
-        <form>
+        <form class="needs-validation" novalidate>
             <div class="mb-3">
                 <label class="form-label">Họ tên</label>
-                <input type="text" class="form-control" name="name"/>
+                <input type="text" class="form-control" name="name" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Số điện thoại</label>
-                <input type="text" class="form-control" name="phone"/>
+                <input type="text" class="form-control" name="phone" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Email</label>
-                <input type="email" class="form-control" name="email"/>
+                <input type="email" class="form-control" name="email" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Ngày sinh</label>
-                <input type="text" class="form-control" name="dateOfBirth"/>
+                <input type="text" class="form-control" name="dateOfBirth" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Số bằng lái</label>
-                <input type="text" class="form-control" name="licenseNumber"/>
+                <input type="text" class="form-control" name="licenseNumber" required/>
             </div>
             <button type="submit" class="btn btn-primary">Lưu</button>
         </form>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/driver/schedule.html
+++ b/src/main/resources/templates/driver/schedule.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Driver Schedule</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -32,5 +33,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/medical/dashboard.html
+++ b/src/main/resources/templates/medical/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Medical Dashboard</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -32,5 +33,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/medical/profile.html
+++ b/src/main/resources/templates/medical/profile.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Medical Profile</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -11,35 +12,36 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Thông tin cá nhân</h2>
-        <form>
+        <form class="needs-validation" novalidate>
             <div class="mb-3">
                 <label class="form-label">Họ tên</label>
-                <input type="text" class="form-control" name="name"/>
+                <input type="text" class="form-control" name="name" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Số điện thoại</label>
-                <input type="text" class="form-control" name="phone"/>
+                <input type="text" class="form-control" name="phone" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Email</label>
-                <input type="email" class="form-control" name="email"/>
+                <input type="email" class="form-control" name="email" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Ngày sinh</label>
-                <input type="text" class="form-control" name="dateOfBirth"/>
+                <input type="text" class="form-control" name="dateOfBirth" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Số giấy phép</label>
-                <input type="text" class="form-control" name="licenseNumber"/>
+                <input type="text" class="form-control" name="licenseNumber" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Chuyên môn</label>
-                <input type="text" class="form-control" name="specialization"/>
+                <input type="text" class="form-control" name="specialization" required/>
             </div>
             <button type="submit" class="btn btn-primary">Lưu</button>
         </form>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/medical/schedule.html
+++ b/src/main/resources/templates/medical/schedule.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Medical Schedule</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
 </head>
 <body>
 <div th:replace="layout/header :: header"></div>
@@ -32,5 +33,6 @@
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dashboard.css and dashboard.js for basic table/form styling and validation
- include these assets on dashboard and management templates
- mark profile forms for validation

## Testing
- `./mvnw -q test` *(fails: Failed to fetch ...)*

------
https://chatgpt.com/codex/tasks/task_b_6861b64c86b08325bc30cf05aca90fea