### PR TITLE
Enhance dashboard pages with data and CRUD actions

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -1,63 +1,188 @@
 package com.project.Ambulance.controller;
 
+import com.project.Ambulance.model.Ambulance;
+import com.project.Ambulance.model.Driver;
+import com.project.Ambulance.model.Hospital;
+import com.project.Ambulance.service.AmbulanceService;
+import com.project.Ambulance.service.BookingService;
+import com.project.Ambulance.service.DriverService;
+import com.project.Ambulance.service.HospitalService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 public class DashboardController {
 
+    @Autowired
+    private AmbulanceService ambulanceService;
+
+    @Autowired
+    private BookingService bookingService;
+
+    @Autowired
+    private DriverService driverService;
+
+    @Autowired
+    private HospitalService hospitalService;
+
     @GetMapping("/admin/dashboard")
-    public String adminDashboard() {
+    public String adminDashboard(Model model) {
+        model.addAttribute("ambulanceCount", ambulanceService.countAll());
+        model.addAttribute("driverCount", driverService.countAll());
+        model.addAttribute("hospitalCount", hospitalService.countAll());
+        model.addAttribute("bookingCount", bookingService.count());
         return "admin/dashboard";
     }
 
     @GetMapping("/driver/dashboard")
-    public String driverDashboard() {
+    public String driverDashboard(Model model) {
+        model.addAttribute("bookings", bookingService.getAllBookings());
         return "driver/dashboard";
     }
 
     @GetMapping("/driver/profile")
-    public String driverProfile() {
+    public String driverProfile(Model model) {
+        Driver driver = driverService.getAllDrivers().stream().findFirst().orElse(null);
+        model.addAttribute("driver", driver);
         return "driver/profile";
     }
 
+    @PostMapping("/driver/profile")
+    public String updateDriver(@ModelAttribute("driver") Driver driver) {
+        driverService.saveDriver(driver);
+        return "redirect:/driver/profile";
+    }
+
     @GetMapping("/driver/schedule")
-    public String driverSchedule() {
+    public String driverSchedule(Model model) {
+        model.addAttribute("bookings", bookingService.getAllBookings());
         return "driver/schedule";
     }
 
     @GetMapping("/medical/dashboard")
-    public String medicalDashboard() {
+    public String medicalDashboard(Model model) {
+        model.addAttribute("bookings", bookingService.getAllBookings());
         return "medical/dashboard";
     }
 
     @GetMapping("/medical/profile")
-    public String medicalProfile() {
+    public String medicalProfile(Model model) {
         return "medical/profile";
     }
 
     @GetMapping("/medical/schedule")
-    public String medicalSchedule() {
+    public String medicalSchedule(Model model) {
+        model.addAttribute("bookings", bookingService.getAllBookings());
         return "medical/schedule";
     }
 
     @GetMapping("/admin/ambulances")
-    public String manageAmbulances() {
+    public String manageAmbulances(Model model) {
+        model.addAttribute("ambulances", ambulanceService.getAllAmbulances());
+        model.addAttribute("ambulanceForm", new Ambulance());
         return "admin/ambulances";
     }
 
+    @PostMapping("/admin/ambulances")
+    public String createAmbulance(@ModelAttribute("ambulanceForm") Ambulance ambulance) {
+        ambulanceService.saveAmbulance(ambulance);
+        return "redirect:/admin/ambulances";
+    }
+
+    @GetMapping("/admin/ambulance/{id}/delete")
+    public String deleteAmbulance(@PathVariable int id) {
+        ambulanceService.deleteAmbulance(id);
+        return "redirect:/admin/ambulances";
+    }
+
+    @GetMapping("/admin/ambulance/{id}/edit")
+    public String editAmbulanceForm(@PathVariable int id, Model model) {
+        Ambulance ambulance = ambulanceService.getAmbulanceById(id);
+        model.addAttribute("ambulanceForm", ambulance);
+        return "admin/ambulance-edit";
+    }
+
+    @PostMapping("/admin/ambulance/{id}/edit")
+    public String updateAmbulance(@PathVariable int id,
+                                  @ModelAttribute("ambulanceForm") Ambulance ambulance) {
+        ambulance.setIdAmbulance(id);
+        ambulanceService.saveAmbulance(ambulance);
+        return "redirect:/admin/ambulances";
+    }
+
     @GetMapping("/admin/hospitals")
-    public String manageHospitals() {
+    public String manageHospitals(Model model) {
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("hospitalForm", new Hospital());
         return "admin/hospitals";
     }
 
+    @PostMapping("/admin/hospitals")
+    public String createHospital(@ModelAttribute("hospitalForm") Hospital hospital) {
+        hospitalService.saveHospital(hospital);
+        return "redirect:/admin/hospitals";
+    }
+
+    @GetMapping("/admin/hospital/{id}/delete")
+    public String deleteHospital(@PathVariable int id) {
+        hospitalService.deleteHospital(id);
+        return "redirect:/admin/hospitals";
+    }
+
+    @GetMapping("/admin/hospital/{id}/edit")
+    public String editHospitalForm(@PathVariable int id, Model model) {
+        Hospital hospital = hospitalService.getHospitalById(id);
+        model.addAttribute("hospitalForm", hospital);
+        return "admin/hospital-edit";
+    }
+
+    @PostMapping("/admin/hospital/{id}/edit")
+    public String updateHospital(@PathVariable int id,
+                                 @ModelAttribute("hospitalForm") Hospital hospital) {
+        hospital.setIdHospital(id);
+        hospitalService.saveHospital(hospital);
+        return "redirect:/admin/hospitals";
+    }
+
     @GetMapping("/admin/drivers")
-    public String manageDrivers() {
+    public String manageDrivers(Model model) {
+        model.addAttribute("drivers", driverService.getAllDrivers());
+        model.addAttribute("driverForm", new Driver());
         return "admin/drivers";
     }
 
+    @PostMapping("/admin/drivers")
+    public String createDriver(@ModelAttribute("driverForm") Driver driver) {
+        driverService.saveDriver(driver);
+        return "redirect:/admin/drivers";
+    }
+
+    @GetMapping("/admin/driver/{id}/delete")
+    public String deleteDriver(@PathVariable int id) {
+        driverService.deleteDriver(id);
+        return "redirect:/admin/drivers";
+    }
+
+    @GetMapping("/admin/driver/{id}/edit")
+    public String editDriverForm(@PathVariable int id, Model model) {
+        Driver driver = driverService.getDriverById(id);
+        model.addAttribute("driverForm", driver);
+        return "admin/driver-edit";
+    }
+
+    @PostMapping("/admin/driver/{id}/edit")
+    public String updateDriver(@PathVariable int id,
+                               @ModelAttribute("driverForm") Driver driver) {
+        driver.setIdDriver(id);
+        driverService.saveDriver(driver);
+        return "redirect:/admin/drivers";
+    }
+
     @GetMapping("/admin/bookings")
-    public String bookingHistory() {
+    public String bookingHistory(Model model) {
+        model.addAttribute("bookings", bookingService.getAllBookings());
         return "admin/booking-history";
     }
 }

--- a/src/main/resources/templates/admin/ambulance-edit.html
+++ b/src/main/resources/templates/admin/ambulance-edit.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Ambulance</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật xe cứu thương</h2>
+        <form th:action="@{'/admin/ambulance/' + ${ambulanceForm.idAmbulance} + '/edit'}" method="post" th:object="${ambulanceForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên xe</label>
+                <input type="text" th:field="*{name}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Biển số</label>
+                <input type="text" th:field="*{licensePlate}" class="form-control" required />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/ambulances}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/ambulances.html
+++ b/src/main/resources/templates/admin/ambulances.html
@@ -12,6 +12,40 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Quản lý xe cứu thương</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên xe</th>
+                <th>Biển số</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="a : ${ambulances}">
+                <td th:text="${a.idAmbulance}"></td>
+                <td th:text="${a.name}"></td>
+                <td th:text="${a.licensePlate}"></td>
+                <td>
+                    <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Thêm xe mới</h4>
+        <form th:action="@{/admin/ambulances}" method="post" th:object="${ambulanceForm}" class="row g-3">
+            <div class="col-md-4">
+                <input type="text" th:field="*{name}" class="form-control" placeholder="Tên xe" required />
+            </div>
+            <div class="col-md-4">
+                <input type="text" th:field="*{licensePlate}" class="form-control" placeholder="Biển số" required />
+            </div>
+            <div class="col-md-4">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+            </div>
+        </form>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>

--- a/src/main/resources/templates/admin/booking-history.html
+++ b/src/main/resources/templates/admin/booking-history.html
@@ -12,6 +12,24 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Lịch sử điều xe</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Người yêu cầu</th>
+                <th>Số điện thoại</th>
+                <th>Địa điểm đón</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="b : ${bookings}">
+                <td th:text="${b.idBooking}"></td>
+                <td th:text="${b.requesterName}"></td>
+                <td th:text="${b.phone}"></td>
+                <td th:text="${b.pickupAddress}"></td>
+            </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Dashboard</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Tổng quan</h2>
+        <div class="row text-center mt-3">
+            <div class="col-md-3">
+                <div class="border p-3 bg-light">
+                    <p class="mb-1">Xe cứu thương</p>
+                    <h4 th:text="${ambulanceCount}">0</h4>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="border p-3 bg-light">
+                    <p class="mb-1">Tài xế</p>
+                    <h4 th:text="${driverCount}">0</h4>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="border p-3 bg-light">
+                    <p class="mb-1">Bệnh viện</p>
+                    <h4 th:text="${hospitalCount}">0</h4>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="border p-3 bg-light">
+                    <p class="mb-1">Lịch điều xe</p>
+                    <h4 th:text="${bookingCount}">0</h4>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/driver-edit.html
+++ b/src/main/resources/templates/admin/driver-edit.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Driver</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật tài xế</h2>
+        <form th:action="@{'/admin/driver/' + ${driverForm.idDriver} + '/edit'}" method="post" th:object="${driverForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Họ tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/drivers}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/drivers.html
+++ b/src/main/resources/templates/admin/drivers.html
@@ -12,6 +12,40 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Quản lý tài xế</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Họ tên</th>
+                <th>Số điện thoại</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="d : ${drivers}">
+                <td th:text="${d.idDriver}"></td>
+                <td th:text="${d.name}"></td>
+                <td th:text="${d.phone}"></td>
+                <td>
+                    <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Thêm tài xế</h4>
+        <form th:action="@{/admin/drivers}" method="post" th:object="${driverForm}" class="row g-3">
+            <div class="col-md-4">
+                <input type="text" th:field="*{name}" class="form-control" placeholder="Họ tên" required />
+            </div>
+            <div class="col-md-4">
+                <input type="text" th:field="*{phone}" class="form-control" placeholder="SĐT" required />
+            </div>
+            <div class="col-md-4">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+            </div>
+        </form>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>

--- a/src/main/resources/templates/admin/hospital-edit.html
+++ b/src/main/resources/templates/admin/hospital-edit.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Hospital</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="layout/header :: header"></div>
+<div class="d-flex">
+    <div th:replace="layout/sidebar :: sidebar"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật bệnh viện</h2>
+        <form th:action="@{'/admin/hospital/' + ${hospitalForm.idHospital} + '/edit'}" method="post" th:object="${hospitalForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <label class="form-label">Địa chỉ</label>
+                <input type="text" th:field="*{addressDetail}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/hospitals}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="layout/footer :: footer"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/hospitals.html
+++ b/src/main/resources/templates/admin/hospitals.html
@@ -12,6 +12,40 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Quản lý bệnh viện</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên bệnh viện</th>
+                <th>Điện thoại</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="h : ${hospitals}">
+                <td th:text="${h.idHospital}"></td>
+                <td th:text="${h.name}"></td>
+                <td th:text="${h.phone}"></td>
+                <td>
+                    <a th:href="@{'/admin/hospital/' + ${h.idHospital} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/hospital/' + ${h.idHospital} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Thêm bệnh viện</h4>
+        <form th:action="@{/admin/hospitals}" method="post" th:object="${hospitalForm}" class="row g-3">
+            <div class="col-md-4">
+                <input type="text" th:field="*{name}" class="form-control" placeholder="Tên" required />
+            </div>
+            <div class="col-md-4">
+                <input type="text" th:field="*{phone}" class="form-control" placeholder="Điện thoại" required />
+            </div>
+            <div class="col-md-4">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+            </div>
+        </form>
     </div>
 </div>
 <div th:replace="layout/footer :: footer"></div>

--- a/src/main/resources/templates/driver/dashboard.html
+++ b/src/main/resources/templates/driver/dashboard.html
@@ -24,7 +24,7 @@
             <tbody>
                 <tr th:each="b : ${bookings}">
                     <td th:text="${b.idBooking}"></td>
-                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${#dates.format(b.requestTime, 'yyyy-MM-dd HH:mm')}"></td>
                     <td th:text="${b.pickupAddress}"></td>
                     <td th:text="${b.hospital.name}"></td>
                 </tr>

--- a/src/main/resources/templates/driver/profile.html
+++ b/src/main/resources/templates/driver/profile.html
@@ -12,26 +12,27 @@
     <div th:replace="layout/sidebar :: sidebar"></div>
     <div class="flex-fill p-3">
         <h2>Thông tin cá nhân</h2>
-        <form class="needs-validation" novalidate>
+        <form th:action="@{/driver/profile}" method="post" th:object="${driver}" class="needs-validation" novalidate>
+            <input type="hidden" th:field="*{idDriver}" />
             <div class="mb-3">
                 <label class="form-label">Họ tên</label>
-                <input type="text" class="form-control" name="name" required/>
+                <input type="text" class="form-control" th:field="*{name}" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Số điện thoại</label>
-                <input type="text" class="form-control" name="phone" required/>
+                <input type="text" class="form-control" th:field="*{phone}" required/>
             </div>
             <div class="mb-3">
                 <label class="form-label">Email</label>
-                <input type="email" class="form-control" name="email" required/>
+                <input type="email" class="form-control" th:field="*{email}" />
             </div>
             <div class="mb-3">
                 <label class="form-label">Ngày sinh</label>
-                <input type="text" class="form-control" name="dateOfBirth" required/>
+                <input type="text" class="form-control" th:field="*{dateOfBirth}" />
             </div>
             <div class="mb-3">
                 <label class="form-label">Số bằng lái</label>
-                <input type="text" class="form-control" name="licenseNumber" required/>
+                <input type="text" class="form-control" th:field="*{licenseNumber}" />
             </div>
             <button type="submit" class="btn btn-primary">Lưu</button>
         </form>

--- a/src/main/resources/templates/driver/schedule.html
+++ b/src/main/resources/templates/driver/schedule.html
@@ -24,7 +24,7 @@
             <tbody>
                 <tr th:each="b : ${bookings}">
                     <td th:text="${b.idBooking}"></td>
-                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${#dates.format(b.requestTime, 'yyyy-MM-dd HH:mm')}"></td>
                     <td th:text="${b.pickupAddress}"></td>
                     <td th:text="${b.hospital.name}"></td>
                 </tr>

--- a/src/main/resources/templates/medical/dashboard.html
+++ b/src/main/resources/templates/medical/dashboard.html
@@ -24,7 +24,7 @@
             <tbody>
                 <tr th:each="b : ${bookings}">
                     <td th:text="${b.idBooking}"></td>
-                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${#dates.format(b.requestTime, 'yyyy-MM-dd HH:mm')}"></td>
                     <td th:text="${b.pickupAddress}"></td>
                     <td th:text="${b.hospital.name}"></td>
                 </tr>

--- a/src/main/resources/templates/medical/schedule.html
+++ b/src/main/resources/templates/medical/schedule.html
@@ -24,7 +24,7 @@
             <tbody>
                 <tr th:each="b : ${bookings}">
                     <td th:text="${b.idBooking}"></td>
-                    <td th:text="${b.startTime}"></td>
+                    <td th:text="${#dates.format(b.requestTime, 'yyyy-MM-dd HH:mm')}"></td>
                     <td th:text="${b.pickupAddress}"></td>
                     <td th:text="${b.hospital.name}"></td>
                 </tr>


### PR DESCRIPTION
## Summary
- inject service layer in `DashboardController`
- load data for admin, driver and medical pages
- add CRUD form handling endpoints for ambulances, hospitals and drivers
- implement admin dashboard overview page
- render admin tables with add/edit/delete controls
- add driver profile update form

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861bc314e708325ab8fd8cf469623a2