### PR TITLE
Remove html wrappers from layout fragments

### DIFF
--- a/src/main/resources/templates/layout/footer.html
+++ b/src/main/resources/templates/layout/footer.html
@@ -1,9 +1,4 @@
-<!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
-<body>
 <footer th:fragment="footer" class="text-center mt-4 mb-3">
     <p class="text-muted">&copy; 2025 Ambulance Management</p>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </footer>
-</body>
-</html>

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -1,11 +1,3 @@
-<!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head th:fragment="head(title)">
-    <meta charset="UTF-8">
-    <title th:text="${title}">Ambulance</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
-</head>
-<body>
 <header th:fragment="header">
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <a class="navbar-brand" th:href="@{/}">Ambulance</a>
@@ -15,5 +7,3 @@
         </div>
     </nav>
 </header>
-</body>
-</html>

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -1,6 +1,3 @@
-<!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
-<body>
 <nav th:fragment="sidebar" class="d-flex flex-column flex-shrink-0 p-3 bg-light" style="width: 200px;">
     <ul class="nav nav-pills flex-column mb-auto" th:switch="${session.loggedInUser?.role?.name}">
         <th:block th:case="'ADMIN'">
@@ -22,5 +19,3 @@
         </th:block>
     </ul>
 </nav>
-</body>
-</html>


### PR DESCRIPTION
## Summary
- clean up `header.html`, `sidebar.html` and `footer.html`
- export only the fragment without any `<html>` or `<body>` wrappers

## Testing
- `./mvnw -q test` *(fails: network access required)*
- `./mvnw -q -DskipTests package` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_6861f79d27208325b4040792cd57cf54