### PR TITLE
Fix driver profile editing scope

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -4,11 +4,13 @@ import com.project.Ambulance.model.Ambulance;
 import com.project.Ambulance.model.Driver;
 import com.project.Ambulance.model.Hospital;
 import com.project.Ambulance.model.MedicalStaff;
+import com.project.Ambulance.model.User;
 import com.project.Ambulance.service.AmbulanceService;
 import com.project.Ambulance.service.BookingService;
 import com.project.Ambulance.service.DriverService;
 import com.project.Ambulance.service.HospitalService;
 import com.project.Ambulance.service.MedicalStaffService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -48,14 +50,23 @@ public class DashboardController {
     }
 
     @GetMapping("/driver/profile")
-    public String driverProfile(Model model) {
-        Driver driver = driverService.getAllDrivers().stream().findFirst().orElse(null);
+    public String driverProfile(Model model, HttpSession session) {
+        User loggedIn = (User) session.getAttribute("loggedInUser");
+        if (loggedIn == null) {
+            return "redirect:/login";
+        }
+        Driver driver = driverService.getDriverById(loggedIn.getIdUser());
         model.addAttribute("driver", driver);
         return "driver/profile";
     }
 
     @PostMapping("/driver/profile")
-    public String updateDriver(@ModelAttribute("driver") Driver driver) {
+    public String updateDriver(@ModelAttribute("driver") Driver driver, HttpSession session) {
+        User loggedIn = (User) session.getAttribute("loggedInUser");
+        if (loggedIn == null) {
+            return "redirect:/login";
+        }
+        driver.setIdDriver(loggedIn.getIdUser());
         driverService.saveDriver(driver);
         return "redirect:/driver/profile";
     }

--- a/src/main/java/com/project/Ambulance/controller/DriverController.java
+++ b/src/main/java/com/project/Ambulance/controller/DriverController.java
@@ -1,10 +1,12 @@
 package com.project.Ambulance.controller;
 
 import com.project.Ambulance.model.Driver;
+import com.project.Ambulance.model.User;
 import com.project.Ambulance.service.DriverService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.servlet.http.HttpSession;
 
 import java.util.List;
 
@@ -67,19 +69,26 @@ public class DriverController {
 
     // === DRIVER APIs ===
 
-    @GetMapping("/driver/profile/{id}")
-    public ResponseEntity<Driver> getProfile(@PathVariable int id) {
-        Driver driver = driverService.getDriverById(id);
+    @GetMapping("/driver/profile")
+    public ResponseEntity<Driver> getProfile(HttpSession session) {
+        User loggedIn = (User) session.getAttribute("loggedInUser");
+        if (loggedIn == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        Driver driver = driverService.getDriverById(loggedIn.getIdUser());
         if (driver == null) {
             return ResponseEntity.notFound().build();
         }
         return ResponseEntity.ok(driver);
     }
 
-    @PutMapping("/driver/profile/{id}")
-    public ResponseEntity<Driver> updateProfile(@PathVariable int id,
-                                                @RequestBody Driver driver) {
-        driver.setIdDriver(id);
+    @PutMapping("/driver/profile")
+    public ResponseEntity<Driver> updateProfile(@RequestBody Driver driver, HttpSession session) {
+        User loggedIn = (User) session.getAttribute("loggedInUser");
+        if (loggedIn == null) {
+            return ResponseEntity.badRequest().build();
+        }
+        driver.setIdDriver(loggedIn.getIdUser());
         Driver updated = driverService.saveDriver(driver);
         return ResponseEntity.ok(updated);
     }

--- a/src/main/resources/templates/driver/profile.html
+++ b/src/main/resources/templates/driver/profile.html
@@ -13,7 +13,6 @@
     <div class="flex-fill p-3">
         <h2>Thông tin cá nhân</h2>
         <form th:action="@{/driver/profile}" method="post" th:object="${driver}" class="needs-validation" novalidate>
-            <input type="hidden" th:field="*{idDriver}" />
             <div class="mb-3">
                 <label class="form-label">Họ tên</label>
                 <input type="text" class="form-control" th:field="*{name}" required/>


### PR DESCRIPTION
## Summary
- ensure driver profile pages load data for the logged-in driver using session info
- restrict profile update endpoints to the logged-in user
- remove hidden id field from driver profile form

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861fbbd748883259098bc7153e0bdab