### PR TITLE
Add admin management pages for provinces, districts and wards

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -5,11 +5,17 @@ import com.project.Ambulance.model.Driver;
 import com.project.Ambulance.model.Hospital;
 import com.project.Ambulance.model.MedicalStaff;
 import com.project.Ambulance.model.User;
+import com.project.Ambulance.model.Province;
+import com.project.Ambulance.model.District;
+import com.project.Ambulance.model.Ward;
 import com.project.Ambulance.service.AmbulanceService;
 import com.project.Ambulance.service.BookingService;
 import com.project.Ambulance.service.DriverService;
 import com.project.Ambulance.service.HospitalService;
 import com.project.Ambulance.service.MedicalStaffService;
+import com.project.Ambulance.service.ProvinceService;
+import com.project.Ambulance.service.DistrictService;
+import com.project.Ambulance.service.WardService;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -33,6 +39,15 @@ public class DashboardController {
 
     @Autowired
     private MedicalStaffService medicalStaffService;
+
+    @Autowired
+    private ProvinceService provinceService;
+
+    @Autowired
+    private DistrictService districtService;
+
+    @Autowired
+    private WardService wardService;
 
     @GetMapping("/admin/dashboard")
     public String adminDashboard(Model model) {
@@ -226,5 +241,129 @@ public class DashboardController {
     public String bookingHistory(Model model) {
         model.addAttribute("bookings", bookingService.getAllBookings());
         return "pages/booking/index.booking";
+    }
+
+    // === Province Management ===
+    @GetMapping("/admin/provinces")
+    public String manageProvinces(Model model) {
+        model.addAttribute("provinces", provinceService.getAllProvinceOrderByName());
+        return "pages/province/index.province";
+    }
+
+    @GetMapping("/admin/province/add")
+    public String addProvinceForm(Model model) {
+        model.addAttribute("provinceForm", new Province());
+        return "pages/province/add.province";
+    }
+
+    @PostMapping("/admin/provinces")
+    public String createProvince(@ModelAttribute("provinceForm") Province province) {
+        provinceService.saveProvince(province);
+        return "redirect:/admin/provinces";
+    }
+
+    @GetMapping("/admin/province/{id}/delete")
+    public String deleteProvince(@PathVariable int id) {
+        provinceService.deleteProvince(id);
+        return "redirect:/admin/provinces";
+    }
+
+    @GetMapping("/admin/province/{id}/edit")
+    public String editProvinceForm(@PathVariable int id, Model model) {
+        Province province = provinceService.getProvince(id);
+        model.addAttribute("provinceForm", province);
+        return "pages/province/update.province";
+    }
+
+    @PostMapping("/admin/province/{id}/edit")
+    public String updateProvince(@PathVariable int id,
+                                 @ModelAttribute("provinceForm") Province province) {
+        province.setIdProvince(id);
+        provinceService.saveProvince(province);
+        return "redirect:/admin/provinces";
+    }
+
+    // === District Management ===
+    @GetMapping("/admin/districts")
+    public String manageDistricts(Model model) {
+        model.addAttribute("districts", districtService.getAllDistrict());
+        return "pages/district/index.district";
+    }
+
+    @GetMapping("/admin/district/add")
+    public String addDistrictForm(Model model) {
+        model.addAttribute("districtForm", new District());
+        model.addAttribute("provinces", provinceService.getAllProvinceOrderByName());
+        return "pages/district/add.district";
+    }
+
+    @PostMapping("/admin/districts")
+    public String createDistrict(@ModelAttribute("districtForm") District district) {
+        districtService.saveDistrict(district);
+        return "redirect:/admin/districts";
+    }
+
+    @GetMapping("/admin/district/{id}/delete")
+    public String deleteDistrict(@PathVariable int id) {
+        districtService.deleteDistrict(id);
+        return "redirect:/admin/districts";
+    }
+
+    @GetMapping("/admin/district/{id}/edit")
+    public String editDistrictForm(@PathVariable int id, Model model) {
+        District district = districtService.getDistrict(id);
+        model.addAttribute("districtForm", district);
+        model.addAttribute("provinces", provinceService.getAllProvinceOrderByName());
+        return "pages/district/update.district";
+    }
+
+    @PostMapping("/admin/district/{id}/edit")
+    public String updateDistrict(@PathVariable int id,
+                                 @ModelAttribute("districtForm") District district) {
+        district.setIdDistrict(id);
+        districtService.saveDistrict(district);
+        return "redirect:/admin/districts";
+    }
+
+    // === Ward Management ===
+    @GetMapping("/admin/wards")
+    public String manageWards(Model model) {
+        model.addAttribute("wards", wardService.getAllWard());
+        return "pages/ward/index.ward";
+    }
+
+    @GetMapping("/admin/ward/add")
+    public String addWardForm(Model model) {
+        model.addAttribute("wardForm", new Ward());
+        model.addAttribute("districts", districtService.getAllDistrict());
+        return "pages/ward/add.ward";
+    }
+
+    @PostMapping("/admin/wards")
+    public String createWard(@ModelAttribute("wardForm") Ward ward) {
+        wardService.saveWard(ward);
+        return "redirect:/admin/wards";
+    }
+
+    @GetMapping("/admin/ward/{id}/delete")
+    public String deleteWard(@PathVariable int id) {
+        wardService.deleteWard(id);
+        return "redirect:/admin/wards";
+    }
+
+    @GetMapping("/admin/ward/{id}/edit")
+    public String editWardForm(@PathVariable int id, Model model) {
+        Ward ward = wardService.getAWard(id);
+        model.addAttribute("wardForm", ward);
+        model.addAttribute("districts", districtService.getAllDistrict());
+        return "pages/ward/update.ward";
+    }
+
+    @PostMapping("/admin/ward/{id}/edit")
+    public String updateWard(@PathVariable int id,
+                             @ModelAttribute("wardForm") Ward ward) {
+        ward.setIdWard(id);
+        wardService.saveWard(ward);
+        return "redirect:/admin/wards";
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -10,13 +10,22 @@ INSERT INTO roles (id_role, name, description) VALUES
 INSERT INTO province (id_province, name_province, zip_code, img_province, create_date, update_date) VALUES
   (1, 'Sample Province', 10000, 'province.png', NOW(), NOW());
 
+INSERT INTO province (id_province, name_province, zip_code, img_province, create_date, update_date) VALUES
+  (2, 'Second Province', 20000, 'province2.png', NOW(), NOW());
+
 -- Districts
 INSERT INTO district (id_district, name_district, create_date, update_date, id_province) VALUES
   (1, 'Sample District', NOW(), NOW(), 1);
 
+INSERT INTO district (id_district, name_district, create_date, update_date, id_province) VALUES
+  (2, 'Second District', NOW(), NOW(), 2);
+
 -- Wards
 INSERT INTO ward (id_ward, name_ward, create_date, update_date, id_district) VALUES
   (1, 'Sample Ward', NOW(), NOW(), 1);
+
+INSERT INTO ward (id_ward, name_ward, create_date, update_date, id_district) VALUES
+  (2, 'Second Ward', NOW(), NOW(), 2);
 
 -- Brand of ambulances
 INSERT INTO brand_ambulance (id_brand, name_brand, create_date, update_date) VALUES

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -5,6 +5,9 @@
             <li><a class="nav-link" th:href="@{/admin/ambulances}">Quản lý xe</a></li>
             <li><a class="nav-link" th:href="@{/admin/hospitals}">Quản lý bệnh viện</a></li>
             <li><a class="nav-link" th:href="@{/admin/drivers}">Quản lý tài xế</a></li>
+            <li><a class="nav-link" th:href="@{/admin/provinces}">Quản lý tỉnh</a></li>
+            <li><a class="nav-link" th:href="@{/admin/districts}">Quản lý huyện</a></li>
+            <li><a class="nav-link" th:href="@{/admin/wards}">Quản lý phường</a></li>
             <li><a class="nav-link" th:href="@{/admin/bookings}">Lịch sử điều xe</a></li>
         </th:block>
         <th:block th:case="'DRIVER'">

--- a/src/main/resources/templates/pages/district/add.district.html
+++ b/src/main/resources/templates/pages/district/add.district.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Add District</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Thêm huyện</h2>
+        <form th:action="@{/admin/districts}" method="post" th:object="${districtForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên huyện</label>
+                <input type="text" th:field="*{nameDistrict}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Tỉnh</label>
+                <select th:field="*{province.idProvince}" class="form-select">
+                    <option th:each="p : ${provinces}" th:value="${p.idProvince}" th:text="${p.nameProvince}"></option>
+                </select>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/districts}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/district/index.district.html
+++ b/src/main/resources/templates/pages/district/index.district.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Districts</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý huyện</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên huyện</th>
+                <th>Tỉnh</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="d : ${districts}">
+                <td th:text="${d.idDistrict}"></td>
+                <td th:text="${d.nameDistrict}"></td>
+                <td th:text="${d.province.nameProvince}"></td>
+                <td>
+                    <a th:href="@{'/admin/district/' + ${d.idDistrict} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/district/' + ${d.idDistrict} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <a th:href="@{/admin/district/add}" class="btn btn-primary mt-3">Thêm huyện</a>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/district/update.district.html
+++ b/src/main/resources/templates/pages/district/update.district.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit District</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật huyện</h2>
+        <form th:action="@{'/admin/district/' + ${districtForm.idDistrict} + '/edit'}" method="post" th:object="${districtForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên huyện</label>
+                <input type="text" th:field="*{nameDistrict}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Tỉnh</label>
+                <select th:field="*{province.idProvince}" class="form-select">
+                    <option th:each="p : ${provinces}" th:value="${p.idProvince}" th:text="${p.nameProvince}"></option>
+                </select>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/districts}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/province/add.province.html
+++ b/src/main/resources/templates/pages/province/add.province.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Add Province</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Thêm tỉnh</h2>
+        <form th:action="@{/admin/provinces}" method="post" th:object="${provinceForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên tỉnh</label>
+                <input type="text" th:field="*{nameProvince}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Mã bưu chính</label>
+                <input type="number" th:field="*{zipCode}" class="form-control" />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Ảnh</label>
+                <input type="text" th:field="*{imgProvince}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/provinces}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/province/index.province.html
+++ b/src/main/resources/templates/pages/province/index.province.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Provinces</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý tỉnh</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên tỉnh</th>
+                <th>Mã bưu chính</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="p : ${provinces}">
+                <td th:text="${p.idProvince}"></td>
+                <td th:text="${p.nameProvince}"></td>
+                <td th:text="${p.zipCode}"></td>
+                <td>
+                    <a th:href="@{'/admin/province/' + ${p.idProvince} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/province/' + ${p.idProvince} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <a th:href="@{/admin/province/add}" class="btn btn-primary mt-3">Thêm tỉnh</a>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/province/update.province.html
+++ b/src/main/resources/templates/pages/province/update.province.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Province</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật tỉnh</h2>
+        <form th:action="@{'/admin/province/' + ${provinceForm.idProvince} + '/edit'}" method="post" th:object="${provinceForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên tỉnh</label>
+                <input type="text" th:field="*{nameProvince}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Mã bưu chính</label>
+                <input type="number" th:field="*{zipCode}" class="form-control" />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Ảnh</label>
+                <input type="text" th:field="*{imgProvince}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/provinces}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/ward/add.ward.html
+++ b/src/main/resources/templates/pages/ward/add.ward.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Add Ward</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Thêm phường</h2>
+        <form th:action="@{/admin/wards}" method="post" th:object="${wardForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên phường</label>
+                <input type="text" th:field="*{nameWard}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Huyện</label>
+                <select th:field="*{district.idDistrict}" class="form-select">
+                    <option th:each="d : ${districts}" th:value="${d.idDistrict}" th:text="${d.nameDistrict}"></option>
+                </select>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/wards}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/ward/index.ward.html
+++ b/src/main/resources/templates/pages/ward/index.ward.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Wards</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý phường</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên phường</th>
+                <th>Huyện</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="w : ${wards}">
+                <td th:text="${w.idWard}"></td>
+                <td th:text="${w.nameWard}"></td>
+                <td th:text="${w.district.nameDistrict}"></td>
+                <td>
+                    <a th:href="@{'/admin/ward/' + ${w.idWard} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{'/admin/ward/' + ${w.idWard} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <a th:href="@{/admin/ward/add}" class="btn btn-primary mt-3">Thêm phường</a>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/ward/update.ward.html
+++ b/src/main/resources/templates/pages/ward/update.ward.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Ward</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật phường</h2>
+        <form th:action="@{'/admin/ward/' + ${wardForm.idWard} + '/edit'}" method="post" th:object="${wardForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên phường</label>
+                <input type="text" th:field="*{nameWard}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Huyện</label>
+                <select th:field="*{district.idDistrict}" class="form-select">
+                    <option th:each="d : ${districts}" th:value="${d.idDistrict}" th:text="${d.nameDistrict}"></option>
+                </select>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/wards}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add CRUD views and routes for provinces, districts and wards
- provide navigation links in admin sidebar
- seed some additional locations in `data.sql`

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_686203bad0188325ada94bac7e90b9c7