### PR TITLE
Add medical staff status constants

### DIFF
--- a/src/main/java/com/project/Ambulance/constants/FieldName.java
+++ b/src/main/java/com/project/Ambulance/constants/FieldName.java
@@ -14,8 +14,13 @@ public interface FieldName {
 
 	// Trạng thái tài xế: 0 = đang rảnh, 1 = đang làm nhiệm vụ, 2 = tạm ngưng hoạt động
 	public static final int DRIVER_STATUS_AVAILABLE = 0;
-	public static final int DRIVER_STATUS_ON_DUTY = 1;
-	public static final int DRIVER_STATUS_SUSPENDED = 2;
+        public static final int DRIVER_STATUS_ON_DUTY = 1;
+        public static final int DRIVER_STATUS_SUSPENDED = 2;
+
+        // Trạng thái nhân viên y tế: 0 = rảnh, 1 = đang làm việc, 2 = tạm nghỉ
+        public static final int MEDICAL_STATUS_AVAILABLE = 0;
+        public static final int MEDICAL_STATUS_ON_DUTY = 1;
+        public static final int MEDICAL_STATUS_SUSPENDED = 2;
 	
 	// Trạng thái hoạt động xe cứu thương: 0 = hoạt động, 1 = bảo trì, 2 = hỏng, 3 = dừng sử dụng
 	public static final int AMBULANCE_STATUS_ACTIVE = 0;

--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -111,7 +111,8 @@ public class DashboardController {
 
     @GetMapping("/medical/profile")
     public String medicalProfile(Model model) {
-        MedicalStaff medicalStaff = medicalStaffService.getAllMedicalStaff()
+        MedicalStaff medicalStaff = medicalStaffService
+                .getAvailableMedicalStaff()
                 .stream()
                 .findFirst()
                 .orElse(null);

--- a/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
+++ b/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
@@ -2,6 +2,7 @@ package com.project.Ambulance.controller;
 
 import com.project.Ambulance.model.MedicalStaff;
 import com.project.Ambulance.service.MedicalStaffService;
+import com.project.Ambulance.constants.FieldName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -33,6 +34,8 @@ public class MedicalStaffController {
 
     @PostMapping("/admin/medicalStaffs")
     public ResponseEntity<?> createMedicalStaff(@RequestBody MedicalStaff staff) {
+        // Newly created staff are available by default
+        staff.setStatus(FieldName.MEDICAL_STATUS_AVAILABLE);
         MedicalStaff saved = medicalStaffService.save(staff);
         return ResponseEntity.ok(saved);
     }

--- a/src/main/java/com/project/Ambulance/repository/MedicalStaffRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/MedicalStaffRepository.java
@@ -31,6 +31,7 @@ public interface MedicalStaffRepository extends JpaRepository<MedicalStaff, Inte
     // Tìm theo trạng thái
     List<MedicalStaff> findByStatusOrderByNameAsc(int status);
 
+
     // Tìm theo bệnh viện
     List<MedicalStaff> findByHospitalIdHospitalOrderByNameAsc(int hospitalId);
 

--- a/src/main/java/com/project/Ambulance/service/MedicalStaffService.java
+++ b/src/main/java/com/project/Ambulance/service/MedicalStaffService.java
@@ -12,6 +12,8 @@ public interface MedicalStaffService {
 
     List<MedicalStaff> getByStatus(int status);
 
+    List<MedicalStaff> getAvailableMedicalStaff();
+
     List<MedicalStaff> getByHospitalAndStatus(int hospitalId, int status);
 
     List<MedicalStaff> searchByName(String name);

--- a/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.Ambulance.service;
 
 import com.project.Ambulance.model.MedicalStaff;
 import com.project.Ambulance.repository.MedicalStaffRepository;
+import com.project.Ambulance.constants.FieldName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +27,11 @@ public class MedicalStaffServiceImpl implements MedicalStaffService {
     @Override
     public List<MedicalStaff> getByStatus(int status) {
         return medicalStaffRepository.findByStatusOrderByNameAsc(status);
+    }
+
+    @Override
+    public List<MedicalStaff> getAvailableMedicalStaff() {
+        return medicalStaffRepository.findByStatusOrderByNameAsc(FieldName.MEDICAL_STATUS_AVAILABLE);
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add constants for medical staff statuses
- default new medical staff to available
- expose a service helper for available medical staff
- use helper in dashboard profile view

## Testing
- `./mvnw -q test` *(fails: Maven download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68621437725083258ab8f3dcbece5cbf