### PR TITLE
Validate updateStatus inputs

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/AmbulanceController.java
+++ b/src/main/java/com/project/Ambulance/controller/AmbulanceController.java
@@ -55,8 +55,12 @@ public class AmbulanceController {
     @PutMapping("/admin/ambulance/{id}/status")
     public ResponseEntity<Void> updateAmbulanceStatus(@PathVariable int id,
                                                       @RequestParam int status) {
-        ambulanceService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            ambulanceService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/admin/ambulances/search")

--- a/src/main/java/com/project/Ambulance/controller/BookingController.java
+++ b/src/main/java/com/project/Ambulance/controller/BookingController.java
@@ -56,8 +56,12 @@ public class BookingController {
     @PutMapping("/admin/booking/{id}/status")
     public ResponseEntity<?> updateBookingStatus(@PathVariable int id,
                                                  @RequestParam int status) {
-        bookingService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            bookingService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     @GetMapping("/admin/bookings/search")

--- a/src/main/java/com/project/Ambulance/controller/DriverController.java
+++ b/src/main/java/com/project/Ambulance/controller/DriverController.java
@@ -63,8 +63,12 @@ public class DriverController {
     @PutMapping("/admin/driver/{id}/status")
     public ResponseEntity<Void> updateDriverStatus(@PathVariable int id,
                                                    @RequestParam int status) {
-        driverService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            driverService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     // === DRIVER APIs ===
@@ -96,8 +100,12 @@ public class DriverController {
     @PutMapping("/driver/status/{id}")
     public ResponseEntity<Void> updateStatus(@PathVariable int id,
                                              @RequestParam int status) {
-        driverService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            driverService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }
 

--- a/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
+++ b/src/main/java/com/project/Ambulance/controller/MedicalStaffController.java
@@ -74,8 +74,12 @@ public class MedicalStaffController {
     @PutMapping("/admin/medicalStaff/{id}/status")
     public ResponseEntity<?> updateMedicalStaffStatus(@PathVariable int id,
                                                       @RequestParam int status) {
-        medicalStaffService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            medicalStaffService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 
     // === MEDICAL STAFF APIs ===
@@ -99,8 +103,12 @@ public class MedicalStaffController {
     @PutMapping("/medical/status/{id}")
     public ResponseEntity<?> updateStatus(@PathVariable int id,
                                           @RequestParam int status) {
-        medicalStaffService.updateStatus(id, status);
-        return ResponseEntity.ok().build();
+        try {
+            medicalStaffService.updateStatus(id, status);
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
     }
 }
 

--- a/src/main/java/com/project/Ambulance/service/AmbulanceServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/AmbulanceServiceImpl.java
@@ -61,6 +61,12 @@ public class AmbulanceServiceImpl implements AmbulanceService {
 
     @Override
     public void updateStatus(int id, int status) {
+        if (status != FieldName.AMBULANCE_STATUS_ACTIVE &&
+            status != FieldName.AMBULANCE_STATUS_MAINTENANCE &&
+            status != FieldName.AMBULANCE_STATUS_BROKEN &&
+            status != FieldName.AMBULANCE_STATUS_DECOMMISSIONED) {
+            throw new IllegalArgumentException("Invalid ambulance status: " + status);
+        }
         ambulanceRepository.updateStatus(id, status);
     }
 

--- a/src/main/java/com/project/Ambulance/service/BookingServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/BookingServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project.Ambulance.service;
 
 import com.project.Ambulance.model.Booking;
+import com.project.Ambulance.constants.FieldName;
 import com.project.Ambulance.repository.BookingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -56,6 +57,12 @@ public class BookingServiceImpl implements BookingService {
 
     @Override
     public void updateStatus(int id, int status) {
+        if (status != FieldName.STATUS_PENDING &&
+            status != FieldName.STATUS_IN_PROGRESS &&
+            status != FieldName.STATUS_COMPLETED &&
+            status != FieldName.STATUS_CANCELLED) {
+            throw new IllegalArgumentException("Invalid booking status: " + status);
+        }
         bookingRepository.updateStatus(id, status);
     }
 

--- a/src/main/java/com/project/Ambulance/service/DriverServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/DriverServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.Ambulance.service;
 
 import com.project.Ambulance.model.Driver;
 import com.project.Ambulance.repository.DriverRepository;
+import com.project.Ambulance.constants.FieldName;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -65,6 +66,11 @@ public class DriverServiceImpl implements DriverService {
 
     @Override
     public void updateStatus(int id, int status) {
+        if (status != FieldName.DRIVER_STATUS_AVAILABLE &&
+            status != FieldName.DRIVER_STATUS_ON_DUTY &&
+            status != FieldName.DRIVER_STATUS_SUSPENDED) {
+            throw new IllegalArgumentException("Invalid driver status: " + status);
+        }
         driverRepository.updateStatus(id, status);
     }
 

--- a/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
@@ -71,6 +71,11 @@ public class MedicalStaffServiceImpl implements MedicalStaffService {
 
     @Override
     public void updateStatus(int id, int status) {
+        if (status != FieldName.MEDICAL_STATUS_AVAILABLE &&
+            status != FieldName.MEDICAL_STATUS_ON_DUTY &&
+            status != FieldName.MEDICAL_STATUS_SUSPENDED) {
+            throw new IllegalArgumentException("Invalid medical staff status: " + status);
+        }
         medicalStaffRepository.updateStatus(id, status);
     }
 


### PR DESCRIPTION
## Summary
- validate status codes before updating entities
- return `IllegalArgumentException` if an invalid code is supplied
- handle validation errors in booking, driver, medical staff, and ambulance controllers

## Testing
- `./mvnw -q test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_b_686215e6364c83259075e2f2820ca003