### PR TITLE
Add status management interface

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/StatusController.java
+++ b/src/main/java/com/project/Ambulance/controller/StatusController.java
@@ -1,0 +1,113 @@
+package com.project.Ambulance.controller;
+
+import com.project.Ambulance.constants.AppConstants;
+import com.project.Ambulance.model.Ambulance;
+import com.project.Ambulance.model.Driver;
+import com.project.Ambulance.model.MedicalStaff;
+import com.project.Ambulance.model.Booking;
+import com.project.Ambulance.service.AmbulanceService;
+import com.project.Ambulance.service.DriverService;
+import com.project.Ambulance.service.MedicalStaffService;
+import com.project.Ambulance.service.BookingService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Controller
+public class StatusController {
+
+    @Autowired
+    private AmbulanceService ambulanceService;
+
+    @Autowired
+    private DriverService driverService;
+
+    @Autowired
+    private MedicalStaffService medicalStaffService;
+
+    @Autowired
+    private BookingService bookingService;
+
+    private Map<Integer, String> ambulanceStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.AMBULANCE_STATUS_ACTIVE, "Hoạt động");
+        map.put(AppConstants.AMBULANCE_STATUS_MAINTENANCE, "Bảo trì");
+        map.put(AppConstants.AMBULANCE_STATUS_BROKEN, "Hỏng");
+        map.put(AppConstants.AMBULANCE_STATUS_DECOMMISSIONED, "Dừng sử dụng");
+        return map;
+    }
+
+    private Map<Integer, String> driverStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.DRIVER_STATUS_AVAILABLE, "Đang rảnh");
+        map.put(AppConstants.DRIVER_STATUS_ON_DUTY, "Đang làm nhiệm vụ");
+        map.put(AppConstants.DRIVER_STATUS_SUSPENDED, "Tạm ngưng hoạt động");
+        return map;
+    }
+
+    private Map<Integer, String> medicalStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.MEDICAL_STATUS_AVAILABLE, "Rảnh");
+        map.put(AppConstants.MEDICAL_STATUS_ON_DUTY, "Đang làm việc");
+        map.put(AppConstants.MEDICAL_STATUS_SUSPENDED, "Tạm nghỉ");
+        return map;
+    }
+
+    private Map<Integer, String> bookingStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.STATUS_PENDING, "Chờ xác nhận");
+        map.put(AppConstants.STATUS_IN_PROGRESS, "Đang xử lý");
+        map.put(AppConstants.STATUS_COMPLETED, "Hoàn thành");
+        map.put(AppConstants.STATUS_CANCELLED, "Hủy");
+        return map;
+    }
+
+    @GetMapping("/admin/status")
+    public String statusPage(Model model) {
+        List<Ambulance> ambulances = ambulanceService.getAllAmbulances();
+        List<Driver> drivers = driverService.getAllDrivers();
+        List<MedicalStaff> medicalStaff = medicalStaffService.getAllMedicalStaff();
+        List<Booking> bookings = bookingService.getAllBookings();
+
+        model.addAttribute("ambulances", ambulances);
+        model.addAttribute("drivers", drivers);
+        model.addAttribute("medicalStaff", medicalStaff);
+        model.addAttribute("bookings", bookings);
+
+        model.addAttribute("ambulanceStatusMap", ambulanceStatusMap());
+        model.addAttribute("driverStatusMap", driverStatusMap());
+        model.addAttribute("medicalStatusMap", medicalStatusMap());
+        model.addAttribute("bookingStatusMap", bookingStatusMap());
+
+        return "pages/status/index.status";
+    }
+
+    @PostMapping("/admin/status/ambulance/{id}")
+    public String updateAmbulanceStatus(@PathVariable int id, @RequestParam int status) {
+        ambulanceService.updateStatus(id, status);
+        return "redirect:/admin/status";
+    }
+
+    @PostMapping("/admin/status/driver/{id}")
+    public String updateDriverStatus(@PathVariable int id, @RequestParam int status) {
+        driverService.updateStatus(id, status);
+        return "redirect:/admin/status";
+    }
+
+    @PostMapping("/admin/status/medical/{id}")
+    public String updateMedicalStatus(@PathVariable int id, @RequestParam int status) {
+        medicalStaffService.updateStatus(id, status);
+        return "redirect:/admin/status";
+    }
+
+    @PostMapping("/admin/status/booking/{id}")
+    public String updateBookingStatus(@PathVariable int id, @RequestParam int status) {
+        bookingService.updateStatus(id, status);
+        return "redirect:/admin/status";
+    }
+}

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -9,6 +9,7 @@
             <li><a class="nav-link" th:href="@{/admin/districts}">Quản lý huyện</a></li>
             <li><a class="nav-link" th:href="@{/admin/wards}">Quản lý phường</a></li>
             <li><a class="nav-link" th:href="@{/admin/bookings}">Lịch sử điều xe</a></li>
+            <li><a class="nav-link" th:href="@{/admin/status}">Quản lý trạng thái</a></li>
         </th:block>
         <th:block th:case="'DRIVER'">
             <li class="nav-item"><a class="nav-link" th:href="@{/driver/dashboard}">Dashboard</a></li>

--- a/src/main/resources/templates/pages/status/index.status.html
+++ b/src/main/resources/templates/pages/status/index.status.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Quản lý trạng thái</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý trạng thái</h2>
+
+        <h4 class="mt-4">Xe cứu thương</h4>
+        <table class="table table-bordered mt-2">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên xe</th>
+                <th>Trạng thái</th>
+                <th>Cập nhật</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="a : ${ambulances}">
+                <td th:text="${a.idAmbulance}"></td>
+                <td th:text="${a.name}"></td>
+                <td th:text="${ambulanceStatusMap[a.status]}"></td>
+                <td>
+                    <form th:action="@{'/admin/status/ambulance/' + ${a.idAmbulance}}" method="post" class="d-flex">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(ambulanceStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == a.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Tài xế</h4>
+        <table class="table table-bordered mt-2">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Họ tên</th>
+                <th>Trạng thái</th>
+                <th>Cập nhật</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="d : ${drivers}">
+                <td th:text="${d.idDriver}"></td>
+                <td th:text="${d.name}"></td>
+                <td th:text="${driverStatusMap[d.status]}"></td>
+                <td>
+                    <form th:action="@{'/admin/status/driver/' + ${d.idDriver}}" method="post" class="d-flex">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(driverStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == d.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Nhân viên y tế</h4>
+        <table class="table table-bordered mt-2">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Họ tên</th>
+                <th>Trạng thái</th>
+                <th>Cập nhật</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="m : ${medicalStaff}">
+                <td th:text="${m.idMedicalStaff}"></td>
+                <td th:text="${m.name}"></td>
+                <td th:text="${medicalStatusMap[m.status]}"></td>
+                <td>
+                    <form th:action="@{'/admin/status/medical/' + ${m.idMedicalStaff}}" method="post" class="d-flex">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(medicalStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == m.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <h4 class="mt-4">Đơn điều xe</h4>
+        <table class="table table-bordered mt-2">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Người yêu cầu</th>
+                <th>Trạng thái</th>
+                <th>Cập nhật</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="b : ${bookings}">
+                <td th:text="${b.idBooking}"></td>
+                <td th:text="${b.requesterName}"></td>
+                <td th:text="${bookingStatusMap[b.status]}"></td>
+                <td>
+                    <form th:action="@{'/admin/status/booking/' + ${b.idBooking}}" method="post" class="d-flex">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(bookingStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == b.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create new status management page
- add controller to display and update status for ambulances, drivers, staff, and bookings
- link status management page in sidebar navigation

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68621a2c949c8325ba7363d4a027b303