### PR TITLE
Integrate status updates into management pages

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -9,6 +9,7 @@ import com.project.Ambulance.model.Booking;
 import com.project.Ambulance.model.Province;
 import com.project.Ambulance.model.District;
 import com.project.Ambulance.model.Ward;
+import com.project.Ambulance.constants.AppConstants;
 import com.project.Ambulance.service.AmbulanceService;
 import com.project.Ambulance.service.BookingService;
 import com.project.Ambulance.service.DriverService;
@@ -18,6 +19,8 @@ import com.project.Ambulance.service.ProvinceService;
 import com.project.Ambulance.service.DistrictService;
 import com.project.Ambulance.service.WardService;
 import java.util.Date;
+import java.util.Map;
+import java.util.LinkedHashMap;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -50,6 +53,32 @@ public class DashboardController {
 
     @Autowired
     private WardService wardService;
+
+    private Map<Integer, String> ambulanceStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.AMBULANCE_STATUS_ACTIVE, "Hoạt động");
+        map.put(AppConstants.AMBULANCE_STATUS_MAINTENANCE, "Bảo trì");
+        map.put(AppConstants.AMBULANCE_STATUS_BROKEN, "Hỏng");
+        map.put(AppConstants.AMBULANCE_STATUS_DECOMMISSIONED, "Dừng sử dụng");
+        return map;
+    }
+
+    private Map<Integer, String> driverStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.DRIVER_STATUS_AVAILABLE, "Đang rảnh");
+        map.put(AppConstants.DRIVER_STATUS_ON_DUTY, "Đang làm nhiệm vụ");
+        map.put(AppConstants.DRIVER_STATUS_SUSPENDED, "Tạm ngưng hoạt động");
+        return map;
+    }
+
+    private Map<Integer, String> bookingStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.STATUS_PENDING, "Chờ xác nhận");
+        map.put(AppConstants.STATUS_IN_PROGRESS, "Đang xử lý");
+        map.put(AppConstants.STATUS_COMPLETED, "Hoàn thành");
+        map.put(AppConstants.STATUS_CANCELLED, "Hủy");
+        return map;
+    }
 
     @GetMapping("/admin/dashboard")
     public String adminDashboard(Model model) {
@@ -135,6 +164,7 @@ public class DashboardController {
     @GetMapping("/admin/ambulances")
     public String manageAmbulances(Model model) {
         model.addAttribute("ambulances", ambulanceService.getAllAmbulances());
+        model.addAttribute("ambulanceStatusMap", ambulanceStatusMap());
         return "pages/ambulance/index.ambulance";
     }
 
@@ -213,6 +243,7 @@ public class DashboardController {
     @GetMapping("/admin/drivers")
     public String manageDrivers(Model model) {
         model.addAttribute("drivers", driverService.getAllDrivers());
+        model.addAttribute("driverStatusMap", driverStatusMap());
         return "pages/driver/index.driver";
     }
 
@@ -252,6 +283,7 @@ public class DashboardController {
     @GetMapping("/admin/bookings")
     public String bookingHistory(Model model) {
         model.addAttribute("bookings", bookingService.getAllBookings());
+        model.addAttribute("bookingStatusMap", bookingStatusMap());
         return "pages/booking/index.booking";
     }
 

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -9,7 +9,6 @@
             <li><a class="nav-link" th:href="@{/admin/districts}">Quản lý huyện</a></li>
             <li><a class="nav-link" th:href="@{/admin/wards}">Quản lý phường</a></li>
             <li><a class="nav-link" th:href="@{/admin/bookings}">Lịch sử điều xe</a></li>
-            <li><a class="nav-link" th:href="@{/admin/status}">Quản lý trạng thái</a></li>
         </th:block>
         <th:block th:case="'DRIVER'">
             <li class="nav-item"><a class="nav-link" th:href="@{/driver/dashboard}">Dashboard</a></li>

--- a/src/main/resources/templates/pages/ambulance/index.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/index.ambulance.html
@@ -18,6 +18,7 @@
                 <th>ID</th>
                 <th>Tên xe</th>
                 <th>Biển số</th>
+                <th>Status</th>
                 <th></th>
             </tr>
             </thead>
@@ -26,7 +27,17 @@
                 <td th:text="${a.idAmbulance}"></td>
                 <td th:text="${a.name}"></td>
                 <td th:text="${a.licensePlate}"></td>
+                <td th:text="${ambulanceStatusMap[a.status]}"></td>
                 <td>
+                    <form th:action="@{'/admin/status/ambulance/' + ${a.idAmbulance}}" method="post" class="d-flex mb-1">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(ambulanceStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == a.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
                     <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/booking/index.booking.html
+++ b/src/main/resources/templates/pages/booking/index.booking.html
@@ -20,6 +20,8 @@
                 <th>Người yêu cầu</th>
                 <th>Số điện thoại</th>
                 <th>Địa điểm đón</th>
+                <th>Status</th>
+                <th></th>
             </tr>
             </thead>
             <tbody>
@@ -28,6 +30,18 @@
                 <td th:text="${b.requesterName}"></td>
                 <td th:text="${b.phone}"></td>
                 <td th:text="${b.pickupAddress}"></td>
+                <td th:text="${bookingStatusMap[b.status]}"></td>
+                <td>
+                    <form th:action="@{'/admin/status/booking/' + ${b.idBooking}}" method="post" class="d-flex">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(bookingStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == b.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                </td>
             </tr>
             </tbody>
         </table>

--- a/src/main/resources/templates/pages/driver/index.driver.html
+++ b/src/main/resources/templates/pages/driver/index.driver.html
@@ -18,6 +18,7 @@
                 <th>ID</th>
                 <th>Họ tên</th>
                 <th>Số điện thoại</th>
+                <th>Status</th>
                 <th></th>
             </tr>
             </thead>
@@ -26,7 +27,17 @@
                 <td th:text="${d.idDriver}"></td>
                 <td th:text="${d.name}"></td>
                 <td th:text="${d.phone}"></td>
+                <td th:text="${driverStatusMap[d.status]}"></td>
                 <td>
+                    <form th:action="@{'/admin/status/driver/' + ${d.idDriver}}" method="post" class="d-flex mb-1">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${#maps.entries(driverStatusMap)}"
+                                    th:value="${s.key}"
+                                    th:text="${s.value}"
+                                    th:selected="${s.key == d.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
                     <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>


### PR DESCRIPTION
## Summary
- add status mapping helpers to `DashboardController`
- provide status maps when listing ambulances, drivers and bookings
- include status column and update form directly in each list page
- remove sidebar link to separate status management page

## Testing
- `./mvnw -q test` *(fails: repository download blocked)*

------
https://chatgpt.com/codex/tasks/task_b_68621cfbd66883258bdf84eb8490d233