### PR TITLE
Fix Thymeleaf attribute concatenations

### DIFF
--- a/src/main/resources/templates/pages/ambulance/index.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/index.ambulance.html
@@ -29,7 +29,7 @@
                 <td th:text="${a.licensePlate}"></td>
                 <td th:text="${ambulanceStatusMap[a.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/ambulance/' + ${a.idAmbulance}}" method="post" class="d-flex mb-1">
+                    <form th:action="@{/admin/status/ambulance/{id}(id=${a.idAmbulance})}" method="post" class="d-flex mb-1">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(ambulanceStatusMap)}"
                                     th:value="${s.key}"
@@ -38,8 +38,8 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
-                    <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/ambulance/' + ${a.idAmbulance} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/ambulance/{id}/edit(id=${a.idAmbulance})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/ambulance/{id}/delete(id=${a.idAmbulance})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/ambulance/update.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/update.ambulance.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật xe cứu thương</h2>
-        <form th:action="@{'/admin/ambulance/' + ${ambulanceForm.idAmbulance} + '/edit'}" method="post" th:object="${ambulanceForm}" class="row g-3">
+        <form th:action="@{/admin/ambulance/{id}/edit(id=${ambulanceForm.idAmbulance})}" method="post" th:object="${ambulanceForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Tên xe</label>
                 <input type="text" th:field="*{name}" class="form-control" required />

--- a/src/main/resources/templates/pages/booking/index.booking.html
+++ b/src/main/resources/templates/pages/booking/index.booking.html
@@ -32,7 +32,7 @@
                 <td th:text="${b.pickupAddress}"></td>
                 <td th:text="${bookingStatusMap[b.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/booking/' + ${b.idBooking}}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/booking/{id}(id=${b.idBooking})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(bookingStatusMap)}"
                                     th:value="${s.key}"

--- a/src/main/resources/templates/pages/district/index.district.html
+++ b/src/main/resources/templates/pages/district/index.district.html
@@ -27,8 +27,8 @@
                 <td th:text="${d.nameDistrict}"></td>
                 <td th:text="${d.province.nameProvince}"></td>
                 <td>
-                    <a th:href="@{'/admin/district/' + ${d.idDistrict} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/district/' + ${d.idDistrict} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/district/{id}/edit(id=${d.idDistrict})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/district/{id}/delete(id=${d.idDistrict})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/district/update.district.html
+++ b/src/main/resources/templates/pages/district/update.district.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật huyện</h2>
-        <form th:action="@{'/admin/district/' + ${districtForm.idDistrict} + '/edit'}" method="post" th:object="${districtForm}" class="row g-3">
+        <form th:action="@{/admin/district/{id}/edit(id=${districtForm.idDistrict})}" method="post" th:object="${districtForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Tên huyện</label>
                 <input type="text" th:field="*{nameDistrict}" class="form-control" required />

--- a/src/main/resources/templates/pages/driver/index.driver.html
+++ b/src/main/resources/templates/pages/driver/index.driver.html
@@ -29,7 +29,7 @@
                 <td th:text="${d.phone}"></td>
                 <td th:text="${driverStatusMap[d.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/driver/' + ${d.idDriver}}" method="post" class="d-flex mb-1">
+                    <form th:action="@{/admin/status/driver/{id}(id=${d.idDriver})}" method="post" class="d-flex mb-1">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(driverStatusMap)}"
                                     th:value="${s.key}"
@@ -38,8 +38,8 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
-                    <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/driver/' + ${d.idDriver} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/driver/{id}/edit(id=${d.idDriver})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/driver/{id}/delete(id=${d.idDriver})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/driver/update.driver.html
+++ b/src/main/resources/templates/pages/driver/update.driver.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật tài xế</h2>
-        <form th:action="@{'/admin/driver/' + ${driverForm.idDriver} + '/edit'}" method="post" th:object="${driverForm}" class="row g-3">
+        <form th:action="@{/admin/driver/{id}/edit(id=${driverForm.idDriver})}" method="post" th:object="${driverForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Họ tên</label>
                 <input type="text" th:field="*{name}" class="form-control" required />

--- a/src/main/resources/templates/pages/hospital/index.hospital.html
+++ b/src/main/resources/templates/pages/hospital/index.hospital.html
@@ -27,8 +27,8 @@
                 <td th:text="${h.name}"></td>
                 <td th:text="${h.phone}"></td>
                 <td>
-                    <a th:href="@{'/admin/hospital/' + ${h.idHospital} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/hospital/' + ${h.idHospital} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/hospital/{id}/edit(id=${h.idHospital})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/hospital/{id}/delete(id=${h.idHospital})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/hospital/update.hospital.html
+++ b/src/main/resources/templates/pages/hospital/update.hospital.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật bệnh viện</h2>
-        <form th:action="@{'/admin/hospital/' + ${hospitalForm.idHospital} + '/edit'}" method="post" th:object="${hospitalForm}" class="row g-3">
+        <form th:action="@{/admin/hospital/{id}/edit(id=${hospitalForm.idHospital})}" method="post" th:object="${hospitalForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Tên</label>
                 <input type="text" th:field="*{name}" class="form-control" required />

--- a/src/main/resources/templates/pages/province/index.province.html
+++ b/src/main/resources/templates/pages/province/index.province.html
@@ -27,8 +27,8 @@
                 <td th:text="${p.nameProvince}"></td>
                 <td th:text="${p.zipCode}"></td>
                 <td>
-                    <a th:href="@{'/admin/province/' + ${p.idProvince} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/province/' + ${p.idProvince} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/province/{id}/edit(id=${p.idProvince})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/province/{id}/delete(id=${p.idProvince})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/province/update.province.html
+++ b/src/main/resources/templates/pages/province/update.province.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật tỉnh</h2>
-        <form th:action="@{'/admin/province/' + ${provinceForm.idProvince} + '/edit'}" method="post" th:object="${provinceForm}" class="row g-3">
+        <form th:action="@{/admin/province/{id}/edit(id=${provinceForm.idProvince})}" method="post" th:object="${provinceForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Tên tỉnh</label>
                 <input type="text" th:field="*{nameProvince}" class="form-control" required />

--- a/src/main/resources/templates/pages/status/index.status.html
+++ b/src/main/resources/templates/pages/status/index.status.html
@@ -29,7 +29,7 @@
                 <td th:text="${a.name}"></td>
                 <td th:text="${ambulanceStatusMap[a.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/ambulance/' + ${a.idAmbulance}}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/ambulance/{id}(id=${a.idAmbulance})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(ambulanceStatusMap)}"
                                     th:value="${s.key}"
@@ -59,7 +59,7 @@
                 <td th:text="${d.name}"></td>
                 <td th:text="${driverStatusMap[d.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/driver/' + ${d.idDriver}}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/driver/{id}(id=${d.idDriver})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(driverStatusMap)}"
                                     th:value="${s.key}"
@@ -89,7 +89,7 @@
                 <td th:text="${m.name}"></td>
                 <td th:text="${medicalStatusMap[m.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/medical/' + ${m.idMedicalStaff}}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/medical/{id}(id=${m.idMedicalStaff})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(medicalStatusMap)}"
                                     th:value="${s.key}"
@@ -119,7 +119,7 @@
                 <td th:text="${b.requesterName}"></td>
                 <td th:text="${bookingStatusMap[b.status]}"></td>
                 <td>
-                    <form th:action="@{'/admin/status/booking/' + ${b.idBooking}}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/booking/{id}(id=${b.idBooking})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${#maps.entries(bookingStatusMap)}"
                                     th:value="${s.key}"

--- a/src/main/resources/templates/pages/ward/index.ward.html
+++ b/src/main/resources/templates/pages/ward/index.ward.html
@@ -27,8 +27,8 @@
                 <td th:text="${w.nameWard}"></td>
                 <td th:text="${w.district.nameDistrict}"></td>
                 <td>
-                    <a th:href="@{'/admin/ward/' + ${w.idWard} + '/edit'}" class="btn btn-sm btn-secondary me-1">Sửa</a>
-                    <a th:href="@{'/admin/ward/' + ${w.idWard} + '/delete'}" class="btn btn-sm btn-danger">Xóa</a>
+                    <a th:href="@{/admin/ward/{id}/edit(id=${w.idWard})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/ward/{id}/delete(id=${w.idWard})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/ward/update.ward.html
+++ b/src/main/resources/templates/pages/ward/update.ward.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật phường</h2>
-        <form th:action="@{'/admin/ward/' + ${wardForm.idWard} + '/edit'}" method="post" th:object="${wardForm}" class="row g-3">
+        <form th:action="@{/admin/ward/{id}/edit(id=${wardForm.idWard})}" method="post" th:object="${wardForm}" class="row g-3">
             <div class="col-md-6">
                 <label class="form-label">Tên phường</label>
                 <input type="text" th:field="*{nameWard}" class="form-control" required />


### PR DESCRIPTION
## Summary
- refactor admin templates to use parameterized expressions
- keep expressions on a single line so Thymeleaf parses them

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686222bc2ca08325bd5324236f91df56