### PR TITLE
Extract status mapping utility

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -9,7 +9,7 @@ import com.project.Ambulance.model.Booking;
 import com.project.Ambulance.model.Province;
 import com.project.Ambulance.model.District;
 import com.project.Ambulance.model.Ward;
-import com.project.Ambulance.constants.AppConstants;
+import com.project.Ambulance.util.StatusMappingUtil;
 import com.project.Ambulance.service.AmbulanceService;
 import com.project.Ambulance.service.BookingService;
 import com.project.Ambulance.service.DriverService;
@@ -19,8 +19,6 @@ import com.project.Ambulance.service.ProvinceService;
 import com.project.Ambulance.service.DistrictService;
 import com.project.Ambulance.service.WardService;
 import java.util.Date;
-import java.util.Map;
-import java.util.LinkedHashMap;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -54,31 +52,6 @@ public class DashboardController {
     @Autowired
     private WardService wardService;
 
-    private Map<Integer, String> ambulanceStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.AMBULANCE_STATUS_ACTIVE, "Hoạt động");
-        map.put(AppConstants.AMBULANCE_STATUS_MAINTENANCE, "Bảo trì");
-        map.put(AppConstants.AMBULANCE_STATUS_BROKEN, "Hỏng");
-        map.put(AppConstants.AMBULANCE_STATUS_DECOMMISSIONED, "Dừng sử dụng");
-        return map;
-    }
-
-    private Map<Integer, String> driverStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.DRIVER_STATUS_AVAILABLE, "Đang rảnh");
-        map.put(AppConstants.DRIVER_STATUS_ON_DUTY, "Đang làm nhiệm vụ");
-        map.put(AppConstants.DRIVER_STATUS_SUSPENDED, "Tạm ngưng hoạt động");
-        return map;
-    }
-
-    private Map<Integer, String> bookingStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.STATUS_PENDING, "Chờ xác nhận");
-        map.put(AppConstants.STATUS_IN_PROGRESS, "Đang xử lý");
-        map.put(AppConstants.STATUS_COMPLETED, "Hoàn thành");
-        map.put(AppConstants.STATUS_CANCELLED, "Hủy");
-        return map;
-    }
 
     @GetMapping("/admin/dashboard")
     public String adminDashboard(Model model) {
@@ -164,7 +137,7 @@ public class DashboardController {
     @GetMapping("/admin/ambulances")
     public String manageAmbulances(Model model) {
         model.addAttribute("ambulances", ambulanceService.getAllAmbulances());
-        model.addAttribute("ambulanceStatusMap", ambulanceStatusMap());
+        model.addAttribute("ambulanceStatusMap", StatusMappingUtil.ambulanceStatusMap());
         return "pages/ambulance/index.ambulance";
     }
 
@@ -243,7 +216,7 @@ public class DashboardController {
     @GetMapping("/admin/drivers")
     public String manageDrivers(Model model) {
         model.addAttribute("drivers", driverService.getAllDrivers());
-        model.addAttribute("driverStatusMap", driverStatusMap());
+        model.addAttribute("driverStatusMap", StatusMappingUtil.driverStatusMap());
         return "pages/driver/index.driver";
     }
 
@@ -283,7 +256,7 @@ public class DashboardController {
     @GetMapping("/admin/bookings")
     public String bookingHistory(Model model) {
         model.addAttribute("bookings", bookingService.getAllBookings());
-        model.addAttribute("bookingStatusMap", bookingStatusMap());
+        model.addAttribute("bookingStatusMap", StatusMappingUtil.bookingStatusMap());
         return "pages/booking/index.booking";
     }
 

--- a/src/main/java/com/project/Ambulance/controller/StatusController.java
+++ b/src/main/java/com/project/Ambulance/controller/StatusController.java
@@ -1,6 +1,6 @@
 package com.project.Ambulance.controller;
 
-import com.project.Ambulance.constants.AppConstants;
+import com.project.Ambulance.util.StatusMappingUtil;
 import com.project.Ambulance.model.Ambulance;
 import com.project.Ambulance.model.Driver;
 import com.project.Ambulance.model.MedicalStaff;
@@ -14,9 +14,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 @Controller
 public class StatusController {
@@ -33,39 +31,6 @@ public class StatusController {
     @Autowired
     private BookingService bookingService;
 
-    private Map<Integer, String> ambulanceStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.AMBULANCE_STATUS_ACTIVE, "Hoạt động");
-        map.put(AppConstants.AMBULANCE_STATUS_MAINTENANCE, "Bảo trì");
-        map.put(AppConstants.AMBULANCE_STATUS_BROKEN, "Hỏng");
-        map.put(AppConstants.AMBULANCE_STATUS_DECOMMISSIONED, "Dừng sử dụng");
-        return map;
-    }
-
-    private Map<Integer, String> driverStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.DRIVER_STATUS_AVAILABLE, "Đang rảnh");
-        map.put(AppConstants.DRIVER_STATUS_ON_DUTY, "Đang làm nhiệm vụ");
-        map.put(AppConstants.DRIVER_STATUS_SUSPENDED, "Tạm ngưng hoạt động");
-        return map;
-    }
-
-    private Map<Integer, String> medicalStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.MEDICAL_STATUS_AVAILABLE, "Rảnh");
-        map.put(AppConstants.MEDICAL_STATUS_ON_DUTY, "Đang làm việc");
-        map.put(AppConstants.MEDICAL_STATUS_SUSPENDED, "Tạm nghỉ");
-        return map;
-    }
-
-    private Map<Integer, String> bookingStatusMap() {
-        Map<Integer, String> map = new LinkedHashMap<>();
-        map.put(AppConstants.STATUS_PENDING, "Chờ xác nhận");
-        map.put(AppConstants.STATUS_IN_PROGRESS, "Đang xử lý");
-        map.put(AppConstants.STATUS_COMPLETED, "Hoàn thành");
-        map.put(AppConstants.STATUS_CANCELLED, "Hủy");
-        return map;
-    }
 
     @GetMapping("/admin/status")
     public String statusPage(Model model) {
@@ -79,10 +44,10 @@ public class StatusController {
         model.addAttribute("medicalStaff", medicalStaff);
         model.addAttribute("bookings", bookings);
 
-        model.addAttribute("ambulanceStatusMap", ambulanceStatusMap());
-        model.addAttribute("driverStatusMap", driverStatusMap());
-        model.addAttribute("medicalStatusMap", medicalStatusMap());
-        model.addAttribute("bookingStatusMap", bookingStatusMap());
+        model.addAttribute("ambulanceStatusMap", StatusMappingUtil.ambulanceStatusMap());
+        model.addAttribute("driverStatusMap", StatusMappingUtil.driverStatusMap());
+        model.addAttribute("medicalStatusMap", StatusMappingUtil.medicalStatusMap());
+        model.addAttribute("bookingStatusMap", StatusMappingUtil.bookingStatusMap());
 
         return "pages/status/index.status";
     }

--- a/src/main/java/com/project/Ambulance/util/StatusMappingUtil.java
+++ b/src/main/java/com/project/Ambulance/util/StatusMappingUtil.java
@@ -1,0 +1,47 @@
+package com.project.Ambulance.util;
+
+import com.project.Ambulance.constants.AppConstants;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class StatusMappingUtil {
+
+    private StatusMappingUtil() {
+        // Utility class
+    }
+
+    public static Map<Integer, String> ambulanceStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.AMBULANCE_STATUS_ACTIVE, "Hoạt động");
+        map.put(AppConstants.AMBULANCE_STATUS_MAINTENANCE, "Bảo trì");
+        map.put(AppConstants.AMBULANCE_STATUS_BROKEN, "Hỏng");
+        map.put(AppConstants.AMBULANCE_STATUS_DECOMMISSIONED, "Dừng sử dụng");
+        return map;
+    }
+
+    public static Map<Integer, String> driverStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.DRIVER_STATUS_AVAILABLE, "Đang rảnh");
+        map.put(AppConstants.DRIVER_STATUS_ON_DUTY, "Đang làm nhiệm vụ");
+        map.put(AppConstants.DRIVER_STATUS_SUSPENDED, "Tạm ngưng hoạt động");
+        return map;
+    }
+
+    public static Map<Integer, String> medicalStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.MEDICAL_STATUS_AVAILABLE, "Rảnh");
+        map.put(AppConstants.MEDICAL_STATUS_ON_DUTY, "Đang làm việc");
+        map.put(AppConstants.MEDICAL_STATUS_SUSPENDED, "Tạm nghỉ");
+        return map;
+    }
+
+    public static Map<Integer, String> bookingStatusMap() {
+        Map<Integer, String> map = new LinkedHashMap<>();
+        map.put(AppConstants.STATUS_PENDING, "Chờ xác nhận");
+        map.put(AppConstants.STATUS_IN_PROGRESS, "Đang xử lý");
+        map.put(AppConstants.STATUS_COMPLETED, "Hoàn thành");
+        map.put(AppConstants.STATUS_CANCELLED, "Hủy");
+        return map;
+    }
+}


### PR DESCRIPTION
## Summary
- create a new `StatusMappingUtil` to house common status map methods
- update `DashboardController` and `StatusController` to use the util

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_686223e3b41083259e1b6ad03cce54d2