### PR TITLE
Fix ambulance status dropdown

### DIFF
--- a/src/main/resources/templates/pages/ambulance/index.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/index.ambulance.html
@@ -31,7 +31,7 @@
                 <td>
                     <form th:action="@{/admin/status/ambulance/{id}(id=${a.idAmbulance})}" method="post" class="d-flex mb-1">
                         <select class="form-select form-select-sm me-2" name="status">
-                            <option th:each="s : ${#maps.entries(ambulanceStatusMap)}"
+                            <option th:each="s : ${ambulanceStatusMap}"
                                     th:value="${s.key}"
                                     th:text="${s.value}"
                                     th:selected="${s.key == a.status}"></option>


### PR DESCRIPTION
## Summary
- fix dropdown iteration to avoid thymeleaf error 500

## Testing
- `mvn test` *(fails: Non-resolvable parent POM because the network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_686252d9be848325b7aa426f68cdd5a5