### PR TITLE
Enable ambulance image uploads

### DIFF
--- a/src/main/java/com/project/Ambulance/configuration/MvcConfig.java
+++ b/src/main/java/com/project/Ambulance/configuration/MvcConfig.java
@@ -1,5 +1,7 @@
 package com.project.Ambulance.configuration;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -8,17 +10,26 @@ import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class MvcConfig implements WebMvcConfigurer{
-	 	@Override
-	    public void addResourceHandlers(ResourceHandlerRegistry registry) {
-	        exposeDirectory("uploads", registry);
-	    }
-	 	private void exposeDirectory(String dirName, ResourceHandlerRegistry registry) {
-	        Path uploadDir = Paths.get(dirName);
-	        String uploadPath = uploadDir.toFile().getAbsolutePath();
-	         
-	        if (dirName.startsWith("../")) dirName = dirName.replace("../", "");
-	         
-	        registry.addResourceHandler("/" + dirName + "/**").addResourceLocations("file:/"+ uploadPath + "/");
-	    }
+public class MvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        exposeDirectory("uploads", registry);
+    }
+
+    private void exposeDirectory(String dirName, ResourceHandlerRegistry registry) {
+        Path uploadDir = Paths.get(dirName);
+        try {
+            if (!Files.exists(uploadDir)) {
+                Files.createDirectories(uploadDir);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create upload directory", e);
+        }
+
+        String uploadPath = uploadDir.toFile().getAbsolutePath();
+
+        if (dirName.startsWith("../")) dirName = dirName.replace("../", "");
+
+        registry.addResourceHandler("/" + dirName + "/**").addResourceLocations("file:/" + uploadPath + "/");
+    }
 }

--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -18,6 +18,8 @@ import com.project.Ambulance.service.MedicalStaffService;
 import com.project.Ambulance.service.ProvinceService;
 import com.project.Ambulance.service.DistrictService;
 import com.project.Ambulance.service.WardService;
+import com.project.Ambulance.service.UploadFile;
+import org.springframework.web.multipart.MultipartFile;
 import java.util.Date;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +53,9 @@ public class DashboardController {
 
     @Autowired
     private WardService wardService;
+
+    @Autowired
+    private UploadFile uploadFile;
 
 
     @GetMapping("/admin/dashboard")
@@ -148,7 +153,12 @@ public class DashboardController {
     }
 
     @PostMapping("/admin/ambulances")
-    public String createAmbulance(@ModelAttribute("ambulanceForm") Ambulance ambulance) {
+    public String createAmbulance(@ModelAttribute("ambulanceForm") Ambulance ambulance,
+                                  @RequestParam("imageFile") MultipartFile imageFile) {
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String fileName = uploadFile.uploadSingleFile(imageFile);
+            ambulance.setImage(fileName);
+        }
         ambulanceService.saveAmbulance(ambulance);
         return "redirect:/admin/ambulances";
     }
@@ -168,8 +178,13 @@ public class DashboardController {
 
     @PostMapping("/admin/ambulance/{id}/edit")
     public String updateAmbulance(@PathVariable int id,
-                                  @ModelAttribute("ambulanceForm") Ambulance ambulance) {
+                                  @ModelAttribute("ambulanceForm") Ambulance ambulance,
+                                  @RequestParam("imageFile") MultipartFile imageFile) {
         ambulance.setIdAmbulance(id);
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String fileName = uploadFile.uploadSingleFile(imageFile);
+            ambulance.setImage(fileName);
+        }
         ambulanceService.saveAmbulance(ambulance);
         return "redirect:/admin/ambulances";
     }

--- a/src/main/resources/templates/pages/ambulance/add.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/add.ambulance.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Thêm xe cứu thương</h2>
-        <form th:action="@{/admin/ambulances}" method="post" th:object="${ambulanceForm}" class="row g-3">
+        <form th:action="@{/admin/ambulances}" method="post" th:object="${ambulanceForm}" class="row g-3" enctype="multipart/form-data">
             <div class="col-md-6">
                 <label class="form-label">Tên xe</label>
                 <input type="text" th:field="*{name}" class="form-control" required />
@@ -111,7 +111,7 @@
             </div>
             <div class="col-md-6">
                 <label class="form-label">Ảnh</label>
-                <input type="text" th:field="*{image}" class="form-control" />
+                <input type="file" name="imageFile" class="form-control" />
             </div>
             <div class="col-md-6">
                 <label class="form-label">Vị trí hiện tại</label>

--- a/src/main/resources/templates/pages/ambulance/update.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/update.ambulance.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật xe cứu thương</h2>
-        <form th:action="@{/admin/ambulance/{id}/edit(id=${ambulanceForm.idAmbulance})}" method="post" th:object="${ambulanceForm}" class="row g-3">
+        <form th:action="@{/admin/ambulance/{id}/edit(id=${ambulanceForm.idAmbulance})}" method="post" th:object="${ambulanceForm}" class="row g-3" enctype="multipart/form-data">
             <div class="col-md-6">
                 <label class="form-label">Tên xe</label>
                 <input type="text" th:field="*{name}" class="form-control" required />
@@ -20,6 +20,10 @@
             <div class="col-md-6">
                 <label class="form-label">Biển số</label>
                 <input type="text" th:field="*{licensePlate}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ảnh</label>
+                <input type="file" name="imageFile" class="form-control" />
             </div>
             <div class="col-12">
                 <button type="submit" class="btn btn-primary">Lưu</button>


### PR DESCRIPTION
## Summary
- allow image uploads in ambulance add/edit pages
- save uploaded file in DashboardController
- ensure `uploads` folder exists and is served

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862ad59798083258a414832e04a1d62