### PR TITLE
Add brand ambulance management pages

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -9,6 +9,7 @@ import com.project.Ambulance.model.Booking;
 import com.project.Ambulance.model.Province;
 import com.project.Ambulance.model.District;
 import com.project.Ambulance.model.Ward;
+import com.project.Ambulance.model.BrandAmbulance;
 import com.project.Ambulance.util.StatusMappingUtil;
 import com.project.Ambulance.service.AmbulanceService;
 import com.project.Ambulance.service.BookingService;
@@ -18,6 +19,7 @@ import com.project.Ambulance.service.MedicalStaffService;
 import com.project.Ambulance.service.ProvinceService;
 import com.project.Ambulance.service.DistrictService;
 import com.project.Ambulance.service.WardService;
+import com.project.Ambulance.service.BrandAmbulanceService;
 import com.project.Ambulance.service.UploadFile;
 import org.springframework.web.multipart.MultipartFile;
 import java.util.Date;
@@ -53,6 +55,9 @@ public class DashboardController {
 
     @Autowired
     private WardService wardService;
+
+    @Autowired
+    private BrandAmbulanceService brandAmbulanceService;
 
     @Autowired
     private UploadFile uploadFile;
@@ -448,5 +453,45 @@ public class DashboardController {
         ward.setIdWard(id);
         wardService.saveWard(ward);
         return "redirect:/admin/wards";
+    }
+
+    // === Brand Ambulance Management ===
+    @GetMapping("/admin/brand-ambulances")
+    public String manageBrands(Model model) {
+        model.addAttribute("brands", brandAmbulanceService.getAllBrands());
+        return "pages/brand/index.brand";
+    }
+
+    @GetMapping("/admin/brand-ambulance/add")
+    public String addBrandForm(Model model) {
+        model.addAttribute("brandForm", new BrandAmbulance());
+        return "pages/brand/add.brand";
+    }
+
+    @PostMapping("/admin/brand-ambulances")
+    public String createBrand(@ModelAttribute("brandForm") BrandAmbulance brand) {
+        brandAmbulanceService.saveBrand(brand);
+        return "redirect:/admin/brand-ambulances";
+    }
+
+    @GetMapping("/admin/brand-ambulance/{id}/edit")
+    public String editBrandForm(@PathVariable int id, Model model) {
+        BrandAmbulance brand = brandAmbulanceService.getBrandById(id);
+        model.addAttribute("brandForm", brand);
+        return "pages/brand/update.brand";
+    }
+
+    @PostMapping("/admin/brand-ambulance/{id}/edit")
+    public String updateBrand(@PathVariable int id,
+                              @ModelAttribute("brandForm") BrandAmbulance brand) {
+        brand.setIdBrand(id);
+        brandAmbulanceService.saveBrand(brand);
+        return "redirect:/admin/brand-ambulances";
+    }
+
+    @GetMapping("/admin/brand-ambulance/{id}/delete")
+    public String deleteBrand(@PathVariable int id) {
+        brandAmbulanceService.deleteBrand(id);
+        return "redirect:/admin/brand-ambulances";
     }
 }

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -3,6 +3,7 @@
         <th:block th:case="'ADMIN'">
             <li class="nav-item"><a class="nav-link" th:href="@{/admin/dashboard}">Dashboard</a></li>
             <li><a class="nav-link" th:href="@{/admin/ambulances}">Quản lý xe</a></li>
+            <li><a class="nav-link" th:href="@{/admin/brand-ambulances}">Quản lý hãng xe</a></li>
             <li><a class="nav-link" th:href="@{/admin/hospitals}">Quản lý bệnh viện</a></li>
             <li><a class="nav-link" th:href="@{/admin/drivers}">Quản lý tài xế</a></li>
             <li><a class="nav-link" th:href="@{/admin/provinces}">Quản lý tỉnh</a></li>

--- a/src/main/resources/templates/pages/brand/add.brand.html
+++ b/src/main/resources/templates/pages/brand/add.brand.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Add Brand</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Thêm hãng xe</h2>
+        <form th:action="@{/admin/brand-ambulances}" method="post" th:object="${brandForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên hãng</label>
+                <input type="text" th:field="*{nameBrand}" class="form-control" required />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/brand-ambulances}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/brand/index.brand.html
+++ b/src/main/resources/templates/pages/brand/index.brand.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Brands</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý hãng xe</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Tên hãng</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="b : ${brands}">
+                <td th:text="${b.idBrand}"></td>
+                <td th:text="${b.nameBrand}"></td>
+                <td>
+                    <a th:href="@{/admin/brand-ambulance/{id}/edit(id=${b.idBrand})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/brand-ambulance/{id}/delete(id=${b.idBrand})}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <a th:href="@{/admin/brand-ambulance/add}" class="btn btn-primary mt-3">Thêm hãng</a>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/brand/update.brand.html
+++ b/src/main/resources/templates/pages/brand/update.brand.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Brand</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật hãng xe</h2>
+        <form th:action="@{/admin/brand-ambulance/{id}/edit(id=${brandForm.idBrand})}" method="post" th:object="${brandForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên hãng</label>
+                <input type="text" th:field="*{nameBrand}" class="form-control" required />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/brand-ambulances}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement brand ambulance management pages in Thymeleaf
- add CRUD endpoints for brands in `DashboardController`
- expose brand management link in sidebar

## Testing
- `./mvnw -q test` *(fails: Could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6862c7f3c3ac832582592af931363f4a