### PR TITLE
Enable driver avatar uploads

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -282,11 +282,18 @@ public class DashboardController {
     @GetMapping("/admin/driver/add")
     public String addDriverForm(Model model) {
         model.addAttribute("driverForm", new Driver());
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("driverStatusMap", StatusMappingUtil.driverStatusMap());
         return "pages/driver/add.driver";
     }
 
     @PostMapping("/admin/drivers")
-    public String createDriver(@ModelAttribute("driverForm") Driver driver) {
+    public String createDriver(@ModelAttribute("driverForm") Driver driver,
+                               @RequestParam("imageFile") MultipartFile imageFile) {
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String fileName = uploadFile.uploadSingleFile(imageFile);
+            driver.setAvatar(fileName);
+        }
         driverService.saveDriver(driver);
         return "redirect:/admin/drivers";
     }

--- a/src/main/resources/templates/pages/driver/add.driver.html
+++ b/src/main/resources/templates/pages/driver/add.driver.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Thêm tài xế</h2>
-        <form th:action="@{/admin/drivers}" method="post" th:object="${driverForm}" class="row g-3">
+        <form th:action="@{/admin/drivers}" method="post" th:object="${driverForm}" class="row g-3" enctype="multipart/form-data">
             <div class="col-md-6">
                 <label class="form-label">Họ tên</label>
                 <input type="text" th:field="*{name}" class="form-control" required />
@@ -39,7 +39,7 @@
             </div>
             <div class="col-md-6">
                 <label class="form-label">Ảnh đại diện</label>
-                <input type="text" th:field="*{avatar}" class="form-control" />
+                <input type="file" name="imageFile" class="form-control" />
             </div>
             <div class="col-md-6">
                 <label class="form-label">Trạng thái</label>


### PR DESCRIPTION
## Summary
- handle driver avatar file uploads on the Add Driver form
- serve hospitals and status mappings to the driver add page

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_6862ce1592bc8325af5787e9a6f46465