### PR TITLE
Update driver status display

### DIFF
--- a/src/main/resources/templates/pages/driver/add.driver.html
+++ b/src/main/resources/templates/pages/driver/add.driver.html
@@ -43,7 +43,11 @@
             </div>
             <div class="col-md-6">
                 <label class="form-label">Trạng thái</label>
-                <input type="number" th:field="*{status}" class="form-control" />
+                <select th:field="*{status}" class="form-select">
+                    <option th:each="s : ${driverStatusMap}"
+                            th:value="${s.key}"
+                            th:text="${s.key} + ' - ' + ${s.value}"></option>
+                </select>
             </div>
             <div class="col-md-6">
                 <label class="form-label">Bệnh viện</label>

--- a/src/main/resources/templates/pages/driver/index.driver.html
+++ b/src/main/resources/templates/pages/driver/index.driver.html
@@ -29,13 +29,13 @@
                 <td th:text="${d.name}"></td>
                 <td th:text="${d.phone}"></td>
                 <td><img th:src="@{'/uploads/' + ${d.avatar}}" style="width:100px;"></td>
-                <td th:text="${driverStatusMap[d.status]}"></td>
+                <td th:text="${d.status} + ' - ' + ${driverStatusMap[d.status]}"></td>
                 <td>
                     <form th:action="@{/admin/status/driver/{id}(id=${d.idDriver})}" method="post" class="d-flex mb-1">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${driverStatusMap}"
                                     th:value="${s.key}"
-                                    th:text="${s.value}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
                                     th:selected="${s.key == d.status}"></option>
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>

--- a/src/main/resources/templates/pages/status/index.status.html
+++ b/src/main/resources/templates/pages/status/index.status.html
@@ -33,7 +33,7 @@
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${ambulanceStatusMap}"
                                     th:value="${s.key}"
-                                    th:text="${s.value}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
                                     th:selected="${s.key == a.status}"></option>
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
@@ -57,13 +57,13 @@
             <tr th:each="d : ${drivers}">
                 <td th:text="${d.idDriver}"></td>
                 <td th:text="${d.name}"></td>
-                <td th:text="${driverStatusMap[d.status]}"></td>
+                <td th:text="${d.status} + ' - ' + ${driverStatusMap[d.status]}"></td>
                 <td>
                     <form th:action="@{/admin/status/driver/{id}(id=${d.idDriver})}" method="post" class="d-flex">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${driverStatusMap}"
                                     th:value="${s.key}"
-                                    th:text="${s.value}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
                                     th:selected="${s.key == d.status}"></option>
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
@@ -93,7 +93,7 @@
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${medicalStatusMap}"
                                     th:value="${s.key}"
-                                    th:text="${s.value}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
                                     th:selected="${s.key == m.status}"></option>
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
@@ -123,7 +123,7 @@
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${bookingStatusMap}"
                                     th:value="${s.key}"
-                                    th:text="${s.value}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
                                     th:selected="${s.key == b.status}"></option>
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>


### PR DESCRIPTION
## Summary
- display driver status codes next to status labels
- show id and label in dropdowns
- add driver status dropdown when adding a new driver

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862d4def10c8325987edf8a9aaa0ad6