### PR TITLE
Add admin UI for medical staff management

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -319,6 +319,54 @@ public class DashboardController {
         return "redirect:/admin/drivers";
     }
 
+    // === Medical Staff Management ===
+    @GetMapping("/admin/medicalStaffs")
+    public String manageMedicalStaff(Model model) {
+        model.addAttribute("medicalStaffs", medicalStaffService.getAllMedicalStaff());
+        model.addAttribute("medicalStatusMap", StatusMappingUtil.medicalStatusMap());
+        return "pages/medical/index.medical";
+    }
+
+    @GetMapping("/admin/medical/add")
+    public String addMedicalForm(Model model) {
+        model.addAttribute("medicalForm", new MedicalStaff());
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("medicalStatusMap", StatusMappingUtil.medicalStatusMap());
+        return "pages/medical/add.medical";
+    }
+
+    @PostMapping("/admin/medicalStaffs")
+    public String createMedical(@ModelAttribute("medicalForm") MedicalStaff staff,
+                                @RequestParam(value = "imageFile", required = false) MultipartFile imageFile) {
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String fileName = uploadFile.uploadSingleFile(imageFile);
+            staff.setAvatar(fileName);
+        }
+        medicalStaffService.save(staff);
+        return "redirect:/admin/medicalStaffs";
+    }
+
+    @GetMapping("/admin/medical/{id}/delete")
+    public String deleteMedical(@PathVariable int id) {
+        medicalStaffService.delete(id);
+        return "redirect:/admin/medicalStaffs";
+    }
+
+    @GetMapping("/admin/medical/{id}/edit")
+    public String editMedicalForm(@PathVariable int id, Model model) {
+        MedicalStaff staff = medicalStaffService.getById(id);
+        model.addAttribute("medicalForm", staff);
+        return "pages/medical/update.medical";
+    }
+
+    @PostMapping("/admin/medical/{id}/edit")
+    public String updateMedical(@PathVariable int id,
+                                @ModelAttribute("medicalForm") MedicalStaff staff) {
+        staff.setIdMedicalStaff(id);
+        medicalStaffService.save(staff);
+        return "redirect:/admin/medicalStaffs";
+    }
+
     @GetMapping("/admin/bookings")
     public String bookingHistory(Model model) {
         model.addAttribute("bookings", bookingService.getAllBookings());

--- a/src/main/resources/templates/layout/sidebar.html
+++ b/src/main/resources/templates/layout/sidebar.html
@@ -6,6 +6,7 @@
             <li><a class="nav-link" th:href="@{/admin/brand-ambulances}">Quản lý hãng xe</a></li>
             <li><a class="nav-link" th:href="@{/admin/hospitals}">Quản lý bệnh viện</a></li>
             <li><a class="nav-link" th:href="@{/admin/drivers}">Quản lý tài xế</a></li>
+            <li><a class="nav-link" th:href="@{/admin/medicalStaffs}">Quản lý nhân viên y tế</a></li>
             <li><a class="nav-link" th:href="@{/admin/provinces}">Quản lý tỉnh</a></li>
             <li><a class="nav-link" th:href="@{/admin/districts}">Quản lý huyện</a></li>
             <li><a class="nav-link" th:href="@{/admin/wards}">Quản lý phường</a></li>

--- a/src/main/resources/templates/pages/medical/add.medical.html
+++ b/src/main/resources/templates/pages/medical/add.medical.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Add Medical Staff</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Thêm nhân viên y tế</h2>
+        <form th:action="@{/admin/medicalStaffs}" method="post" th:object="${medicalForm}" class="row g-3" enctype="multipart/form-data">
+            <div class="col-md-6">
+                <label class="form-label">Họ tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Email</label>
+                <input type="email" th:field="*{email}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ngày sinh</label>
+                <input type="text" th:field="*{dateOfBirth}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Giới tính (nam?)</label>
+                <input type="checkbox" th:field="*{sex}" class="form-check-input" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số giấy phép hành nghề</label>
+                <input type="text" th:field="*{licenseNumber}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Chuyên môn</label>
+                <input type="text" th:field="*{specialization}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ảnh đại diện</label>
+                <input type="file" name="imageFile" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Trạng thái</label>
+                <select th:field="*{status}" class="form-select">
+                    <option th:each="s : ${medicalStatusMap}"
+                            th:value="${s.key}"
+                            th:text="${s.key} + ' - ' + ${s.value}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Bệnh viện</label>
+                <select th:field="*{hospital.idHospital}" class="form-select">
+                    <option th:each="h : ${hospitals}" th:value="${h.idHospital}" th:text="${h.name}"></option>
+                </select>
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/medicalStaffs}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/medical/index.medical.html
+++ b/src/main/resources/templates/pages/medical/index.medical.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Manage Medical Staff</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Quản lý nhân viên y tế</h2>
+        <table class="table table-bordered mt-3">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Họ tên</th>
+                <th>Số điện thoại</th>
+                <th>Ảnh đại diện</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="m : ${medicalStaffs}">
+                <td th:text="${m.idMedicalStaff}"></td>
+                <td th:text="${m.name}"></td>
+                <td th:text="${m.phone}"></td>
+                <td><img th:src="@{'/uploads/' + ${m.avatar}}" style="width:100px;"></td>
+                <td th:text="${m.status} + ' - ' + ${medicalStatusMap[m.status]}"></td>
+                <td>
+                    <form th:action="@{/admin/status/medical/{id}(id=${m.idMedicalStaff})}" method="post" class="d-flex mb-1">
+                        <select class="form-select form-select-sm me-2" name="status">
+                            <option th:each="s : ${medicalStatusMap}"
+                                    th:value="${s.key}"
+                                    th:text="${s.key} + ' - ' + ${s.value}"
+                                    th:selected="${s.key == m.status}"></option>
+                        </select>
+                        <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
+                    </form>
+                    <a th:href="@{/admin/medical/{id}/edit(id=${m.idMedicalStaff})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
+                    <a th:href="@{/admin/medical/{id}/delete(id=${m.idMedicalStaff})}" class="btn btn-sm btn-danger">Xóa</a>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+
+        <a th:href="@{/admin/medical/add}" class="btn btn-primary mt-3">Thêm nhân viên</a>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/medical/update.medical.html
+++ b/src/main/resources/templates/pages/medical/update.medical.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Edit Medical Staff</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Cập nhật nhân viên y tế</h2>
+        <form th:action="@{/admin/medical/{id}/edit(id=${medicalForm.idMedicalStaff})}" method="post" th:object="${medicalForm}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Họ tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" />
+            </div>
+            <div class="col-12">
+                <button type="submit" class="btn btn-primary">Lưu</button>
+                <a th:href="@{/admin/medicalStaffs}" class="btn btn-secondary">Hủy</a>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable medical staff CRUD pages and routing in `DashboardController`
- add admin sidebar link to medical staff management
- create Thymeleaf templates for listing, creating, and editing medical staff

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862d65e6c508325a74ca1f261e3084e