### PR TITLE
Improve medical staff edit form

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -356,13 +356,20 @@ public class DashboardController {
     public String editMedicalForm(@PathVariable int id, Model model) {
         MedicalStaff staff = medicalStaffService.getById(id);
         model.addAttribute("medicalForm", staff);
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("medicalStatusMap", StatusMappingUtil.medicalStatusMap());
         return "pages/medical/update.medical";
     }
 
     @PostMapping("/admin/medical/{id}/edit")
     public String updateMedical(@PathVariable int id,
-                                @ModelAttribute("medicalForm") MedicalStaff staff) {
+                                @ModelAttribute("medicalForm") MedicalStaff staff,
+                                @RequestParam(value = "imageFile", required = false) MultipartFile imageFile) {
         staff.setIdMedicalStaff(id);
+        if (imageFile != null && !imageFile.isEmpty()) {
+            String fileName = uploadFile.uploadSingleFile(imageFile);
+            staff.setAvatar(fileName);
+        }
         medicalStaffService.save(staff);
         return "redirect:/admin/medicalStaffs";
     }

--- a/src/main/resources/templates/pages/medical/update.medical.html
+++ b/src/main/resources/templates/pages/medical/update.medical.html
@@ -12,7 +12,7 @@
     <div th:replace="~{layout/sidebar :: sidebar}"></div>
     <div class="flex-fill p-3">
         <h2>Cập nhật nhân viên y tế</h2>
-        <form th:action="@{/admin/medical/{id}/edit(id=${medicalForm.idMedicalStaff})}" method="post" th:object="${medicalForm}" class="row g-3">
+        <form th:action="@{/admin/medical/{id}/edit(id=${medicalForm.idMedicalStaff})}" method="post" th:object="${medicalForm}" class="row g-3" enctype="multipart/form-data">
             <div class="col-md-6">
                 <label class="form-label">Họ tên</label>
                 <input type="text" th:field="*{name}" class="form-control" required />
@@ -20,6 +20,44 @@
             <div class="col-md-6">
                 <label class="form-label">Số điện thoại</label>
                 <input type="text" th:field="*{phone}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Email</label>
+                <input type="email" th:field="*{email}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ngày sinh</label>
+                <input type="text" th:field="*{dateOfBirth}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Giới tính (nam?)</label>
+                <input type="checkbox" th:field="*{sex}" class="form-check-input" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số giấy phép hành nghề</label>
+                <input type="text" th:field="*{licenseNumber}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Chuyên môn</label>
+                <input type="text" th:field="*{specialization}" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ảnh đại diện</label>
+                <input type="file" name="imageFile" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Trạng thái</label>
+                <select th:field="*{status}" class="form-select">
+                    <option th:each="s : ${medicalStatusMap}"
+                            th:value="${s.key}"
+                            th:text="${s.key} + ' - ' + ${s.value}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Bệnh viện</label>
+                <select th:field="*{hospital.idHospital}" class="form-select">
+                    <option th:each="h : ${hospitals}" th:value="${h.idHospital}" th:text="${h.name}"></option>
+                </select>
             </div>
             <div class="col-12">
                 <button type="submit" class="btn btn-primary">Lưu</button>


### PR DESCRIPTION
## Summary
- allow admin to update all medical staff fields
- support avatar upload when editing medical staff

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862d9052d708325b6e7ada297a49a57