### PR TITLE
Add driver/medical selection to booking form

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -23,6 +23,7 @@ import com.project.Ambulance.service.BrandAmbulanceService;
 import com.project.Ambulance.service.UploadFile;
 import org.springframework.web.multipart.MultipartFile;
 import java.util.Date;
+import java.util.List;
 import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -385,16 +386,27 @@ public class DashboardController {
     public String addBookingForm(Model model) {
         model.addAttribute("bookingForm", new Booking());
         model.addAttribute("ambulances", ambulanceService.getAllAmbulances());
+        model.addAttribute("drivers", driverService.getAllDrivers());
+        model.addAttribute("medicalStaff", medicalStaffService.getAllMedicalStaff());
         return "pages/booking/add.booking";
     }
 
     @PostMapping("/admin/bookings")
-    public String createBooking(@ModelAttribute("bookingForm") Booking booking, HttpSession session) {
+    public String createBooking(@ModelAttribute("bookingForm") Booking booking,
+                                @RequestParam int driverId,
+                                @RequestParam(value = "medicalStaffIds", required = false) List<Integer> medicalStaffIds,
+                                HttpSession session) {
         User loggedIn = (User) session.getAttribute("loggedInUser");
         if (loggedIn != null) {
             booking.setUser(loggedIn);
         }
         booking.setRequestTime(new Date());
+        Driver driver = driverService.getDriverById(driverId);
+        booking.setDriver(driver);
+        if (medicalStaffIds != null && !medicalStaffIds.isEmpty()) {
+            List<MedicalStaff> staff = medicalStaffService.getByIds(medicalStaffIds);
+            booking.setMedicalStaffList(staff);
+        }
         bookingService.saveBooking(booking);
         return "redirect:/admin/bookings";
     }

--- a/src/main/java/com/project/Ambulance/model/Booking.java
+++ b/src/main/java/com/project/Ambulance/model/Booking.java
@@ -1,6 +1,7 @@
 package com.project.Ambulance.model;
 
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
@@ -65,4 +66,22 @@ public class Booking {
     @JoinColumn(name = "user_id")
     @JsonIgnore
     private User user;
+
+    // === Tài xế phụ trách ca này ===
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "driver_id")
+    @JsonIgnore
+    private Driver driver;
+
+    // === Nhân viên y tế tham gia ca này ===
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "booking_medicalstaff",
+        joinColumns = @JoinColumn(name = "booking_id"),
+        inverseJoinColumns = @JoinColumn(name = "medicalstaff_id")
+    )
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @JsonIgnore
+    private List<MedicalStaff> medicalStaffList;
 }

--- a/src/main/java/com/project/Ambulance/repository/MedicalStaffRepository.java
+++ b/src/main/java/com/project/Ambulance/repository/MedicalStaffRepository.java
@@ -48,4 +48,7 @@ public interface MedicalStaffRepository extends JpaRepository<MedicalStaff, Inte
     int countByHospitalIdHospital(int hospitalId);
 
     long count();
+
+    // Lấy danh sách theo nhiều id
+    List<MedicalStaff> findByIdMedicalStaffIn(List<Integer> ids);
 }

--- a/src/main/java/com/project/Ambulance/service/MedicalStaffService.java
+++ b/src/main/java/com/project/Ambulance/service/MedicalStaffService.java
@@ -33,4 +33,6 @@ public interface MedicalStaffService {
     int countByHospital(int hospitalId);
 
     long countAll();
+
+    List<MedicalStaff> getByIds(List<Integer> ids);
 }

--- a/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
+++ b/src/main/java/com/project/Ambulance/service/MedicalStaffServiceImpl.java
@@ -88,4 +88,9 @@ public class MedicalStaffServiceImpl implements MedicalStaffService {
     public long countAll() {
         return medicalStaffRepository.count();
     }
+
+    @Override
+    public List<MedicalStaff> getByIds(List<Integer> ids) {
+        return medicalStaffRepository.findByIdMedicalStaffIn(ids);
+    }
 }

--- a/src/main/resources/templates/pages/booking/add.booking.html
+++ b/src/main/resources/templates/pages/booking/add.booking.html
@@ -39,6 +39,18 @@
                     <option th:each="a : ${ambulances}" th:value="${a.idAmbulance}" th:text="${a.name} + ' - ' + ${a.licensePlate}"></option>
                 </select>
             </div>
+            <div class="col-md-6">
+                <label class="form-label">Tài xế</label>
+                <select name="driverId" class="form-select">
+                    <option th:each="d : ${drivers}" th:value="${d.idDriver}" th:text="${d.name}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Nhân viên y tế</label>
+                <select name="medicalStaffIds" class="form-select" multiple>
+                    <option th:each="m : ${medicalStaff}" th:value="${m.idMedicalStaff}" th:text="${m.name}"></option>
+                </select>
+            </div>
             <div class="col-12">
                 <button type="submit" class="btn btn-primary">Lưu</button>
                 <a th:href="@{/admin/bookings}" class="btn btn-secondary">Hủy</a>


### PR DESCRIPTION
## Summary
- expand booking creation to select drivers and medical staff
- store selected driver and staff on each booking
- expose helper method to load multiple medical staff entities
- show driver and medical staff pickers on booking page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_b_6862dc0aaf208325b2ce89c73df923f2