### PR TITLE
Add detail pages and endpoints

### DIFF
--- a/src/main/java/com/project/Ambulance/controller/DashboardController.java
+++ b/src/main/java/com/project/Ambulance/controller/DashboardController.java
@@ -234,6 +234,16 @@ public class DashboardController {
         return "redirect:/admin/ambulances";
     }
 
+    @GetMapping("/admin/ambulance/{id}")
+    public String detailAmbulance(@PathVariable int id, Model model) {
+        Ambulance ambulance = ambulanceService.getAmbulanceById(id);
+        model.addAttribute("ambulance", ambulance);
+        model.addAttribute("brandAmbulances", brandAmbulanceService.getAllBrands());
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("drivers", driverService.getAllDrivers());
+        return "pages/ambulance/detail.ambulance";
+    }
+
     @GetMapping("/admin/hospitals")
     public String manageHospitals(Model model) {
         model.addAttribute("hospitals", hospitalService.getAllHospitals());
@@ -271,6 +281,13 @@ public class DashboardController {
         hospital.setIdHospital(id);
         hospitalService.saveHospital(hospital);
         return "redirect:/admin/hospitals";
+    }
+
+    @GetMapping("/admin/hospital/{id}")
+    public String detailHospital(@PathVariable int id, Model model) {
+        Hospital hospital = hospitalService.getHospitalById(id);
+        model.addAttribute("hospital", hospital);
+        return "pages/hospital/detail.hospital";
     }
 
     @GetMapping("/admin/drivers")
@@ -318,6 +335,13 @@ public class DashboardController {
         driver.setIdDriver(id);
         driverService.saveDriver(driver);
         return "redirect:/admin/drivers";
+    }
+
+    @GetMapping("/admin/driver/{id}")
+    public String detailDriver(@PathVariable int id, Model model) {
+        Driver driver = driverService.getDriverById(id);
+        model.addAttribute("driver", driver);
+        return "pages/driver/detail.driver";
     }
 
     // === Medical Staff Management ===
@@ -375,6 +399,15 @@ public class DashboardController {
         return "redirect:/admin/medicalStaffs";
     }
 
+    @GetMapping("/admin/medical/{id}")
+    public String detailMedical(@PathVariable int id, Model model) {
+        MedicalStaff staff = medicalStaffService.getById(id);
+        model.addAttribute("medicalStaff", staff);
+        model.addAttribute("hospitals", hospitalService.getAllHospitals());
+        model.addAttribute("medicalStatusMap", StatusMappingUtil.medicalStatusMap());
+        return "pages/medical/detail.medical";
+    }
+
     @GetMapping("/admin/bookings")
     public String bookingHistory(Model model) {
         model.addAttribute("bookings", bookingService.getAllBookings());
@@ -409,6 +442,17 @@ public class DashboardController {
         }
         bookingService.saveBooking(booking);
         return "redirect:/admin/bookings";
+    }
+
+    @GetMapping("/admin/booking/{id}")
+    public String detailBooking(@PathVariable int id, Model model) {
+        Booking booking = bookingService.getBooking(id);
+        model.addAttribute("booking", booking);
+        model.addAttribute("ambulances", ambulanceService.getAllAmbulances());
+        model.addAttribute("drivers", driverService.getAllDrivers());
+        model.addAttribute("medicalStaff", medicalStaffService.getAllMedicalStaff());
+        model.addAttribute("bookingStatusMap", StatusMappingUtil.bookingStatusMap());
+        return "pages/booking/detail.booking";
     }
 
     // === Province Management ===
@@ -449,6 +493,13 @@ public class DashboardController {
         province.setIdProvince(id);
         provinceService.saveProvince(province);
         return "redirect:/admin/provinces";
+    }
+
+    @GetMapping("/admin/province/{id}")
+    public String detailProvince(@PathVariable int id, Model model) {
+        Province province = provinceService.getProvince(id);
+        model.addAttribute("province", province);
+        return "pages/province/detail.province";
     }
 
     // === District Management ===
@@ -493,6 +544,14 @@ public class DashboardController {
         return "redirect:/admin/districts";
     }
 
+    @GetMapping("/admin/district/{id}")
+    public String detailDistrict(@PathVariable int id, Model model) {
+        District district = districtService.getDistrict(id);
+        model.addAttribute("district", district);
+        model.addAttribute("provinces", provinceService.getAllProvinceOrderByName());
+        return "pages/district/detail.district";
+    }
+
     // === Ward Management ===
     @GetMapping("/admin/wards")
     public String manageWards(Model model) {
@@ -535,6 +594,14 @@ public class DashboardController {
         return "redirect:/admin/wards";
     }
 
+    @GetMapping("/admin/ward/{id}")
+    public String detailWard(@PathVariable int id, Model model) {
+        Ward ward = wardService.getAWard(id);
+        model.addAttribute("ward", ward);
+        model.addAttribute("districts", districtService.getAllDistrict());
+        return "pages/ward/detail.ward";
+    }
+
     // === Brand Ambulance Management ===
     @GetMapping("/admin/brand-ambulances")
     public String manageBrands(Model model) {
@@ -567,6 +634,13 @@ public class DashboardController {
         brand.setIdBrand(id);
         brandAmbulanceService.saveBrand(brand);
         return "redirect:/admin/brand-ambulances";
+    }
+
+    @GetMapping("/admin/brand-ambulance/{id}")
+    public String detailBrand(@PathVariable int id, Model model) {
+        BrandAmbulance brand = brandAmbulanceService.getBrandById(id);
+        model.addAttribute("brand", brand);
+        return "pages/brand/detail.brand";
     }
 
     @GetMapping("/admin/brand-ambulance/{id}/delete")

--- a/src/main/resources/templates/pages/ambulance/detail.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/detail.ambulance.html
@@ -1,0 +1,144 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Ambulance Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết xe cứu thương</h2>
+        <form th:object="${ambulance}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên xe</label>
+                <input type="text" th:field="*{name}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Biển số</label>
+                <input type="text" th:field="*{licensePlate}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Mô tả</label>
+                <input type="text" th:field="*{description}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Năm sản xuất</label>
+                <input type="number" th:field="*{modelYear}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Trạng thái</label>
+                <input type="number" th:field="*{status}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Loại nhiên liệu (xăng?)</label>
+                <input type="checkbox" th:field="*{fuelType}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Tiêu thụ (l/100km)</label>
+                <input type="number" step="0.1" th:field="*{fuelConsumptionPer100km}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Số ghế</label>
+                <input type="number" th:field="*{numberOfSeats}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Thiết bị y tế</label>
+                <input type="checkbox" th:field="*{medicalEquipment}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Bình oxy</label>
+                <input type="checkbox" th:field="*{oxygenTank}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Máy sốc tim</label>
+                <input type="checkbox" th:field="*{defibrillator}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Máy theo dõi</label>
+                <input type="checkbox" th:field="*{patientMonitor}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Băng ca</label>
+                <input type="checkbox" th:field="*{stretcher}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Treo dịch truyền</label>
+                <input type="checkbox" th:field="*{infusionSupport}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Lồng kính</label>
+                <input type="checkbox" th:field="*{incubatorSupport}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">GPS</label>
+                <input type="checkbox" th:field="*{gpsLocator}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Camera 360</label>
+                <input type="checkbox" th:field="*{camera360}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Camera lùi</label>
+                <input type="checkbox" th:field="*{reverseCamera}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Dash cam</label>
+                <input type="checkbox" th:field="*{dashCamera}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">TPMS</label>
+                <input type="checkbox" th:field="*{tpms}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Cảm biến va chạm</label>
+                <input type="checkbox" th:field="*{impactSensor}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Cảnh báo tốc độ</label>
+                <input type="checkbox" th:field="*{speedWarning}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Điều hòa</label>
+                <input type="checkbox" th:field="*{airConditioning}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Hộp số sàn</label>
+                <input type="checkbox" th:field="*{manualTransmission}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ảnh</label>
+                <input type="file" name="imageFile" class="form-control" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Vị trí hiện tại</label>
+                <input type="text" th:field="*{currentLocation}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Thương hiệu</label>
+                <select disabled th:field="*{brandAmbulance.idBrand}" class="form-select">
+                    <option th:each="b : ${brandAmbulances}" th:value="${b.idBrand}" th:text="${b.nameBrand}"></option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Bệnh viện</label>
+                <select disabled th:field="*{hospital.idHospital}" class="form-select">
+                    <option th:each="h : ${hospitals}" th:value="${h.idHospital}" th:text="${h.name}"></option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Tài xế</label>
+                <select disabled th:field="*{driver.idDriver}" class="form-select">
+                    <option th:each="d : ${drivers}" th:value="${d.idDriver}" th:text="${d.name}"></option>
+                </select>
+            </div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/ambulance/index.ambulance.html
+++ b/src/main/resources/templates/pages/ambulance/index.ambulance.html
@@ -42,6 +42,7 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
+                    <a th:href="@{/admin/ambulance/{id}(id=${a.idAmbulance})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/ambulance/{id}/edit(id=${a.idAmbulance})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/ambulance/{id}/delete(id=${a.idAmbulance})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/booking/detail.booking.html
+++ b/src/main/resources/templates/pages/booking/detail.booking.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Booking Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết điều xe</h2>
+        <form th:object="${booking}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Người yêu cầu</label>
+                <input type="text" th:field="*{requesterName}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Điểm đón</label>
+                <input type="text" th:field="*{pickupAddress}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Điểm đến</label>
+                <input type="text" th:field="*{destinationAddress}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Ghi chú</label>
+                <input type="text" th:field="*{patientConditionNote}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Chọn xe</label>
+                <select disabled name="ambulance.idAmbulance" class="form-select">
+                    <option th:each="a : ${ambulances}" th:value="${a.idAmbulance}" th:text="${a.name} + ' - ' + ${a.licensePlate}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Tài xế</label>
+                <select disabled name="driverId" class="form-select">
+                    <option th:each="d : ${drivers}" th:value="${d.idDriver}" th:text="${d.name}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Nhân viên y tế</label>
+                <select disabled name="medicalStaffIds" class="form-select" multiple>
+                    <option th:each="m : ${medicalStaff}" th:value="${m.idMedicalStaff}" th:text="${m.name}"></option>
+                </select>
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/booking/index.booking.html
+++ b/src/main/resources/templates/pages/booking/index.booking.html
@@ -32,7 +32,7 @@
                 <td th:text="${b.pickupAddress}"></td>
                 <td th:text="${bookingStatusMap[b.status]}"></td>
                 <td>
-                    <form th:action="@{/admin/status/booking/{id}(id=${b.idBooking})}" method="post" class="d-flex">
+                    <form th:action="@{/admin/status/booking/{id}(id=${b.idBooking})}" method="post" class="d-flex mb-1">
                         <select class="form-select form-select-sm me-2" name="status">
                             <option th:each="s : ${bookingStatusMap}"
                                     th:value="${s.key}"
@@ -41,6 +41,7 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
+                    <a th:href="@{/admin/booking/{id}(id=${b.idBooking})}" class="btn btn-sm btn-info">Xem chi tiết</a>
                 </td>
             </tr>
             </tbody>

--- a/src/main/resources/templates/pages/brand/detail.brand.html
+++ b/src/main/resources/templates/pages/brand/detail.brand.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Brand Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết hãng xe</h2>
+        <form th:object="${brand}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên hãng</label>
+                <input type="text" th:field="*{nameBrand}" class="form-control" required readonly />
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/brand/index.brand.html
+++ b/src/main/resources/templates/pages/brand/index.brand.html
@@ -25,6 +25,7 @@
                 <td th:text="${b.idBrand}"></td>
                 <td th:text="${b.nameBrand}"></td>
                 <td>
+                    <a th:href="@{/admin/brand-ambulance/{id}(id=${b.idBrand})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/brand-ambulance/{id}/edit(id=${b.idBrand})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/brand-ambulance/{id}/delete(id=${b.idBrand})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/district/detail.district.html
+++ b/src/main/resources/templates/pages/district/detail.district.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>District Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết huyện</h2>
+        <form th:object="${district}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên huyện</label>
+                <input type="text" th:field="*{nameDistrict}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Tỉnh</label>
+                <select disabled th:field="*{province.idProvince}" class="form-select">
+                    <option th:each="p : ${provinces}" th:value="${p.idProvince}" th:text="${p.nameProvince}"></option>
+                </select>
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/district/index.district.html
+++ b/src/main/resources/templates/pages/district/index.district.html
@@ -27,6 +27,7 @@
                 <td th:text="${d.nameDistrict}"></td>
                 <td th:text="${d.province.nameProvince}"></td>
                 <td>
+                    <a th:href="@{/admin/district/{id}(id=${d.idDistrict})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/district/{id}/edit(id=${d.idDistrict})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/district/{id}/delete(id=${d.idDistrict})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/driver/detail.driver.html
+++ b/src/main/resources/templates/pages/driver/detail.driver.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Driver Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết tài xế</h2>
+        <form th:object="${driver}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Họ tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" readonly />
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/driver/index.driver.html
+++ b/src/main/resources/templates/pages/driver/index.driver.html
@@ -40,6 +40,7 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
+                    <a th:href="@{/admin/driver/{id}(id=${d.idDriver})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/driver/{id}/edit(id=${d.idDriver})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/driver/{id}/delete(id=${d.idDriver})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/hospital/detail.hospital.html
+++ b/src/main/resources/templates/pages/hospital/detail.hospital.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Hospital Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết bệnh viện</h2>
+        <form th:object="${hospital}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control" readonly />
+            </div>
+            <div class="col-12">
+                <label class="form-label">Địa chỉ</label>
+                <input type="text" th:field="*{addressDetail}" class="form-control" readonly />
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/hospital/index.hospital.html
+++ b/src/main/resources/templates/pages/hospital/index.hospital.html
@@ -27,6 +27,7 @@
                 <td th:text="${h.name}"></td>
                 <td th:text="${h.phone}"></td>
                 <td>
+                    <a th:href="@{/admin/hospital/{id}(id=${h.idHospital})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/hospital/{id}/edit(id=${h.idHospital})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/hospital/{id}/delete(id=${h.idHospital})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/medical/detail.medical.html
+++ b/src/main/resources/templates/pages/medical/detail.medical.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Medical Staff Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết nhân viên y tế</h2>
+        <form th:object="${medicalStaff}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Họ tên</label>
+                <input type="text" th:field="*{name}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số điện thoại</label>
+                <input type="text" th:field="*{phone}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Email</label>
+                <input type="email" th:field="*{email}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ngày sinh</label>
+                <input type="text" th:field="*{dateOfBirth}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Giới tính (nam?)</label>
+                <input type="checkbox" th:field="*{sex}" class="form-check-input" disabled />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Số giấy phép hành nghề</label>
+                <input type="text" th:field="*{licenseNumber}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Chuyên môn</label>
+                <input type="text" th:field="*{specialization}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Ảnh đại diện</label>
+                <img th:src="@{'/uploads/' + ${medicalStaff.avatar}}" class="img-fluid" />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Trạng thái</label>
+                <select disabled th:field="*{status}" class="form-select">
+                    <option th:each="s : ${medicalStatusMap}"
+                            th:value="${s.key}"
+                            th:text="${s.key} + ' - ' + ${s.value}"></option>
+                </select>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Bệnh viện</label>
+                <select disabled th:field="*{hospital.idHospital}" class="form-select">
+                    <option th:each="h : ${hospitals}" th:value="${h.idHospital}" th:text="${h.name}"></option>
+                </select>
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/medical/index.medical.html
+++ b/src/main/resources/templates/pages/medical/index.medical.html
@@ -40,6 +40,7 @@
                         </select>
                         <button type="submit" class="btn btn-sm btn-primary">Lưu</button>
                     </form>
+                    <a th:href="@{/admin/medical/{id}(id=${m.idMedicalStaff})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/medical/{id}/edit(id=${m.idMedicalStaff})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/medical/{id}/delete(id=${m.idMedicalStaff})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/province/detail.province.html
+++ b/src/main/resources/templates/pages/province/detail.province.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Province Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết tỉnh</h2>
+        <form th:object="${province}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên tỉnh</label>
+                <input type="text" th:field="*{nameProvince}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Mã bưu chính</label>
+                <input type="number" th:field="*{zipCode}" class="form-control"  readonly />
+            </div>
+            <div class="col-md-12">
+                <label class="form-label">Ảnh</label>
+                <input type="text" th:field="*{imgProvince}" class="form-control"  readonly />
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/province/index.province.html
+++ b/src/main/resources/templates/pages/province/index.province.html
@@ -27,6 +27,7 @@
                 <td th:text="${p.nameProvince}"></td>
                 <td th:text="${p.zipCode}"></td>
                 <td>
+                    <a th:href="@{/admin/province/{id}(id=${p.idProvince})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/province/{id}/edit(id=${p.idProvince})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/province/{id}/delete(id=${p.idProvince})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/main/resources/templates/pages/ward/detail.ward.html
+++ b/src/main/resources/templates/pages/ward/detail.ward.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Ward Detail</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" th:href="@{/css/dashboard.css}" />
+</head>
+<body>
+<div th:replace="~{layout/header :: header}"></div>
+<div class="d-flex">
+    <div th:replace="~{layout/sidebar :: sidebar}"></div>
+    <div class="flex-fill p-3">
+        <h2>Chi tiết phường</h2>
+        <form th:object="${ward}" class="row g-3">
+            <div class="col-md-6">
+                <label class="form-label">Tên phường</label>
+                <input type="text" th:field="*{nameWard}" class="form-control" required  readonly />
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Huyện</label>
+                <select disabled th:field="*{district.idDistrict}" class="form-select">
+                    <option th:each="d : ${districts}" th:value="${d.idDistrict}" th:text="${d.nameDistrict}"></option>
+                </select>
+            </div>
+            <div class="col-12"></div>
+        </form>
+    </div>
+</div>
+<div th:replace="~{layout/footer :: footer}"></div>
+<script th:src="@{/js/dashboard.js}"></script>
+</body>
+</html>

--- a/src/main/resources/templates/pages/ward/index.ward.html
+++ b/src/main/resources/templates/pages/ward/index.ward.html
@@ -27,6 +27,7 @@
                 <td th:text="${w.nameWard}"></td>
                 <td th:text="${w.district.nameDistrict}"></td>
                 <td>
+                    <a th:href="@{/admin/ward/{id}(id=${w.idWard})}" class="btn btn-sm btn-info me-1">Xem chi tiết</a>
                     <a th:href="@{/admin/ward/{id}/edit(id=${w.idWard})}" class="btn btn-sm btn-secondary me-1">Sửa</a>
                     <a th:href="@{/admin/ward/{id}/delete(id=${w.idWard})}" class="btn btn-sm btn-danger">Xóa</a>
                 </td>

--- a/src/test/java/com/project/Ambulance/controller/DashboardDetailControllerTest.java
+++ b/src/test/java/com/project/Ambulance/controller/DashboardDetailControllerTest.java
@@ -1,0 +1,105 @@
+package com.project.Ambulance.controller;
+
+import com.project.Ambulance.model.*;
+import com.project.Ambulance.service.*;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DashboardController.class)
+class DashboardDetailControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean private AmbulanceService ambulanceService;
+    @MockBean private BookingService bookingService;
+    @MockBean private DriverService driverService;
+    @MockBean private HospitalService hospitalService;
+    @MockBean private MedicalStaffService medicalStaffService;
+    @MockBean private ProvinceService provinceService;
+    @MockBean private DistrictService districtService;
+    @MockBean private WardService wardService;
+    @MockBean private BrandAmbulanceService brandAmbulanceService;
+    @MockBean private UploadFile uploadFile;
+
+    @Test
+    void ambulanceDetailReturnsOk() throws Exception {
+        when(ambulanceService.getAmbulanceById(1)).thenReturn(new Ambulance());
+        when(brandAmbulanceService.getAllBrands()).thenReturn(Collections.emptyList());
+        when(hospitalService.getAllHospitals()).thenReturn(Collections.emptyList());
+        when(driverService.getAllDrivers()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/admin/ambulance/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void brandDetailReturnsOk() throws Exception {
+        when(brandAmbulanceService.getBrandById(1)).thenReturn(new BrandAmbulance());
+        mockMvc.perform(get("/admin/brand-ambulance/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void hospitalDetailReturnsOk() throws Exception {
+        when(hospitalService.getHospitalById(1)).thenReturn(new Hospital());
+        mockMvc.perform(get("/admin/hospital/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void driverDetailReturnsOk() throws Exception {
+        when(driverService.getDriverById(1)).thenReturn(new Driver());
+        mockMvc.perform(get("/admin/driver/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void medicalDetailReturnsOk() throws Exception {
+        when(medicalStaffService.getById(1)).thenReturn(new MedicalStaff());
+        when(hospitalService.getAllHospitals()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/admin/medical/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void bookingDetailReturnsOk() throws Exception {
+        when(bookingService.getBooking(1)).thenReturn(new Booking());
+        when(ambulanceService.getAllAmbulances()).thenReturn(Collections.emptyList());
+        when(driverService.getAllDrivers()).thenReturn(Collections.emptyList());
+        when(medicalStaffService.getAllMedicalStaff()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/admin/booking/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void provinceDetailReturnsOk() throws Exception {
+        when(provinceService.getProvince(1)).thenReturn(new Province());
+        mockMvc.perform(get("/admin/province/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void districtDetailReturnsOk() throws Exception {
+        when(districtService.getDistrict(1)).thenReturn(new District());
+        when(provinceService.getAllProvinceOrderByName()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/admin/district/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void wardDetailReturnsOk() throws Exception {
+        when(wardService.getAWard(1)).thenReturn(new Ward());
+        when(districtService.getAllDistrict()).thenReturn(Collections.emptyList());
+        mockMvc.perform(get("/admin/ward/1"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
## Summary
- create Thymeleaf detail views for all entities
- show detail button on each management list
- expose new `/admin/<entity>/{id}` routes
- add tests for the detail endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_b_6862de8ef60083258123c452cd4bd559